### PR TITLE
Support casting a slice of ZST’s to an (empty) slice of non-ZST’s

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,9 @@ pub use pod::*;
 /// Any ZST becomes an empty slice.
 #[inline]
 pub fn bytes_of<T: Pod>(t: &T) -> &[u8] {
-  try_cast_slice::<T, u8>(core::slice::from_ref(t)).unwrap()
+  unsafe {
+    core::slice::from_raw_parts(t as *const T as *const u8, size_of::<T>())
+  }
 }
 
 /// Re-interprets `&mut T` as `&mut [u8]`.
@@ -76,7 +78,9 @@ pub fn bytes_of<T: Pod>(t: &T) -> &[u8] {
 /// Any ZST becomes an empty slice.
 #[inline]
 pub fn bytes_of_mut<T: Pod>(t: &mut T) -> &mut [u8] {
-  try_cast_slice_mut::<T, u8>(core::slice::from_mut(t)).unwrap()
+  unsafe {
+    core::slice::from_raw_parts_mut(t as *mut T as *mut u8, size_of::<T>())
+  }
 }
 
 /// The things that can go wrong when casting between [`Pod`] data forms.

--- a/tests/cast_slice_tests.rs
+++ b/tests/cast_slice_tests.rs
@@ -35,6 +35,12 @@ fn test_try_cast_slice() {
 
   // if we don't mess with it we can up-alignment cast
   try_cast_slice::<u8, u32>(the_bytes).unwrap();
+
+  // ZST to non-ZST
+  assert_eq!(
+    try_cast_slice::<(), u8>(&[(), (), ()]),
+    Ok(&[][..])
+  );
 }
 
 #[test]
@@ -72,6 +78,12 @@ fn test_try_cast_slice_mut() {
 
   // if we don't mess with it we can up-alignment cast
   try_cast_slice_mut::<u8, u32>(the_bytes).unwrap();
+
+  // ZST to non-ZST
+  assert_eq!(
+    try_cast_slice_mut::<(), u8>(&mut [(), (), ()]),
+    Ok(&mut [][..])
+  );
 }
 
 #[test]

--- a/tests/cast_slice_tests.rs
+++ b/tests/cast_slice_tests.rs
@@ -37,10 +37,7 @@ fn test_try_cast_slice() {
   try_cast_slice::<u8, u32>(the_bytes).unwrap();
 
   // ZST to non-ZST
-  assert_eq!(
-    try_cast_slice::<(), u8>(&[(), (), ()]),
-    Ok(&[][..])
-  );
+  assert_eq!(try_cast_slice::<(), u8>(&[(), (), ()]), Ok(&[][..]));
 }
 
 #[test]
@@ -80,10 +77,7 @@ fn test_try_cast_slice_mut() {
   try_cast_slice_mut::<u8, u32>(the_bytes).unwrap();
 
   // ZST to non-ZST
-  assert_eq!(
-    try_cast_slice_mut::<(), u8>(&mut [(), (), ()]),
-    Ok(&mut [][..])
-  );
+  assert_eq!(try_cast_slice_mut::<(), u8>(&mut [(), (), ()]), Ok(&mut [][..]));
 }
 
 #[test]


### PR DESCRIPTION
That limitation seems unnecessary.

The second commit is more subjective, depending on whether you prefer reducing uses of `unsafe` or reducing uses of `unwrap`.