### PR TITLE
add additional license options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "bytemuck"
 description = "A crate for mucking around with piles of bytes."
-version = "1.3.1-alpha.0"
+version = "1.3.0-alpha.0"
 authors = ["Lokathor <zefria@gmail.com>"]
 repository = "https://github.com/Lokathor/bytemuck"
 readme = "README.md"
 keywords = ["transmute", "bytes", "casting"]
 categories = ["encoding", "no-std"]
 edition = "2018"
-license = "Zlib"
+license = "Zlib OR Apache-2.0 OR MIT"
 exclude = ["/scripts/*", "/.travis.yml", "/appveyor.yml", "/bors.toml", "/pedantic.bat"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Hello all, we're adding the standard `Apache-2.0 OR MIT` license options to the crate, in addition to the existing `Zlib` license option. I expect this to be agreeable with everyone since Rust uses these licenses all the time, but I still do need past code contributors to sign off on this:
* [x] @thomcc 
* [x] @SimonSapin 
* [x] @HeroicKatora 

so just comment something like "i agree", or whatever.