### PR TITLE
add basic derive macro for Pod, Zeroable and TransparentWrapper for structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,12 @@ exclude = ["/pedantic.bat"]
 extern_crate_alloc = []
 extern_crate_std = ["extern_crate_alloc"]
 zeroable_maybe_uninit = []
+derive = ["bytemuck_derive"]
+
+[dependencies]
+bytemuck_derive = { version = "1.0", path = "derive", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true
+
+[workspace]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "bytemuck_derive"
+description = "A crate for mucking around with piles of bytes."
+version = "1.0.0"
+authors = ["Lokathor <zefria@gmail.com>"]
+repository = "https://github.com/Lokathor/bytemuck"
+readme = "README.md"
+keywords = ["transmute", "bytes", "casting"]
+categories = ["encoding", "no-std"]
+edition = "2018"
+license = "Zlib OR Apache-2.0 OR MIT"
+
+[lib]
+name = "bytemuck_derive"
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[dev-dependencies]
+bytemuck = { version =  "1.3.2-alpha.0", path = ".." }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,11 +1,37 @@
+//! Derive macros for [bytemuck](https://docs.rs/bytemuck) traits
+
 mod traits;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, spanned::Spanned, Data, DataStruct, DeriveInput};
+use syn::{parse_macro_input, DeriveInput};
 
 use crate::traits::{Derivable, Pod, TransparentWrapper, Zeroable};
 
+/// Derive the `Pod` trait for a struct
+///
+/// The macro ensures that the struct follows all the the safety requirements
+/// for the `Pod` trait.
+///
+/// The following constraints need to be satisfied for the macro to succeed
+///
+/// - All fields in the struct must implement `Pod`
+/// - The struct must be `#[repr(C)]` or `$[repr(transparent)]`
+/// - The struct must not contain any padding bytes
+/// - The struct contains no generic parameters
+///
+/// ## Example
+///
+/// ```rust
+/// # use bytemuck_derive::{Pod, Zeroable};
+///
+/// #[derive(Copy, Clone, Pod, Zeroable)]
+/// #[repr(C)]
+/// struct Test {
+///   a: u16,
+///   b: u16,
+/// }
+/// ```
 #[proc_macro_derive(Pod)]
 pub fn derive_pod(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
   let expanded =
@@ -14,6 +40,27 @@ pub fn derive_pod(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
   proc_macro::TokenStream::from(expanded)
 }
 
+/// Derive the `Zeroable` trait for a struct
+///
+/// The macro ensures that the struct follows all the the safety requirements
+/// for the `Zeroable` trait.
+///
+/// The following constraints need to be satisfied for the macro to succeed
+///
+/// - All fields ind the struct must to implement `Zeroable`
+///
+/// ## Example
+///
+/// ```rust
+/// # use bytemuck_derive::{Zeroable};
+///
+/// #[derive(Copy, Clone, Zeroable)]
+/// #[repr(C)]
+/// struct Test {
+///   a: u16,
+///   b: u16,
+/// }
+/// ```
 #[proc_macro_derive(Zeroable)]
 pub fn derive_zeroable(
   input: proc_macro::TokenStream,
@@ -24,6 +71,34 @@ pub fn derive_zeroable(
   proc_macro::TokenStream::from(expanded)
 }
 
+/// Derive the `TransparentWrapper` trait for a struct
+///
+/// The macro ensures that the struct follows all the the safety requirements
+/// for the `TransparentWrapper` trait.
+///
+/// The following constraints need to be satisfied for the macro to succeed
+///
+/// - The struct must be `#[repr(transparent)]
+/// - The struct must contain the `Wrapped` type
+///
+/// If the struct only contains a single field, the `Wrapped` type will
+/// automatically be determined if there is more then one field in the struct,
+/// you need to specify the `Wrapped` type using `#[transparent(T)]`
+///
+/// ## Example
+///
+/// ```rust
+/// # use bytemuck_derive::TransparentWrapper;
+/// # use std::marker::PhantomData;
+///
+/// #[derive(Copy, Clone, TransparentWrapper)]
+/// #[repr(transparent)]
+/// #[transparent(u16)]
+/// struct Test<T> {
+///   inner: u16,
+///   extra: PhantomData<T>,
+/// }
+/// ```
 #[proc_macro_derive(TransparentWrapper, attributes(transparent))]
 pub fn derive_transparent(
   input: proc_macro::TokenStream,
@@ -35,6 +110,7 @@ pub fn derive_transparent(
   proc_macro::TokenStream::from(expanded)
 }
 
+/// Basic wrapper for error handling
 fn derive_marker_trait<Trait: Derivable>(input: DeriveInput) -> TokenStream {
   derive_marker_trait_inner::<Trait>(input).unwrap_or_else(|err| {
     quote! {
@@ -50,17 +126,10 @@ fn derive_marker_trait_inner<Trait: Derivable>(
 
   let (impl_generics, ty_generics, where_clause) =
     input.generics.split_for_impl();
-  let span = input.span();
-
-  let fields = if let Data::Struct(DataStruct { fields, .. }) = &input.data {
-    fields
-  } else {
-    return Err("deriving this trait is only supported for structs");
-  };
 
   let trait_ = Trait::ident();
   Trait::check_attributes(&input.attrs)?;
-  let asserts = Trait::struct_asserts(name, fields, &input.attrs, span)?;
+  let asserts = Trait::struct_asserts(&input)?;
   let trait_params = Trait::generic_params(&input)?;
 
   Ok(quote! {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -16,7 +16,7 @@ use crate::traits::{Derivable, Pod, TransparentWrapper, Zeroable};
 /// The following constraints need to be satisfied for the macro to succeed
 ///
 /// - All fields in the struct must implement `Pod`
-/// - The struct must be `#[repr(C)]` or `$[repr(transparent)]`
+/// - The struct must be `#[repr(C)]` or `#[repr(transparent)]`
 /// - The struct must not contain any padding bytes
 /// - The struct contains no generic parameters
 ///

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,0 +1,171 @@
+use proc_macro2::{Ident, Span, TokenStream, TokenTree};
+use quote::{quote, quote_spanned};
+use std::iter::empty;
+use syn::{
+  parse_macro_input, spanned::Spanned, AttrStyle, Attribute, Data, DataStruct,
+  DeriveInput, Field, Fields, FieldsNamed, FieldsUnnamed, Type,
+};
+
+trait Derivable {
+  fn ident() -> TokenStream;
+  fn struct_asserts(
+    struct_name: &Ident, fields: &Fields, span: Span,
+  ) -> TokenStream;
+  fn check_attributes(_attributes: &[Attribute]) -> Result<(), TokenStream> {
+    Ok(())
+  }
+}
+
+struct Pod;
+
+impl Derivable for Pod {
+  fn ident() -> TokenStream {
+    quote!(bytemuck::Pod)
+  }
+
+  fn struct_asserts(
+    struct_name: &Ident, fields: &Fields, span: Span,
+  ) -> TokenStream {
+    let assert_no_padding =
+      generate_assert_no_padding(struct_name, fields, span);
+    let assert_fields_are_pod =
+      generate_fields_are_trait(&fields, Self::ident(), span);
+
+    quote!(
+      #assert_no_padding
+      #assert_fields_are_pod
+    )
+  }
+
+  fn check_attributes(attributes: &[Attribute]) -> Result<(), TokenStream> {
+    for attr in attributes {
+      if let (AttrStyle::Outer, Some(outer_ident), Some(inner_ident)) = (
+        &attr.style,
+        attr.path.get_ident(),
+        get_ident_from_stream(attr.tokens.clone()),
+      ) {
+        if outer_ident.to_string() == "repr"
+          && (inner_ident.to_string() == "C"
+            || inner_ident.to_string() == "transparent")
+        {
+          return Ok(());
+        }
+      }
+    }
+
+    Err(quote! {
+      compile_error!("Pod requires the struct to be #[repr(C)] or #[repr(transparent)]");
+    })
+  }
+}
+
+fn get_ident_from_stream(tokens: TokenStream) -> Option<Ident> {
+  match tokens.into_iter().next() {
+    Some(TokenTree::Group(group)) => get_ident_from_stream(group.stream()),
+    Some(TokenTree::Ident(ident)) => Some(ident),
+    _ => None,
+  }
+}
+
+struct Zeroable;
+
+impl Derivable for Zeroable {
+  fn ident() -> TokenStream {
+    quote!(bytemuck::Zeroable)
+  }
+
+  fn struct_asserts(
+    _struct_name: &Ident, fields: &Fields, span: Span,
+  ) -> TokenStream {
+    generate_fields_are_trait(fields, Self::ident(), span)
+  }
+}
+
+#[proc_macro_derive(Pod)]
+pub fn derive_pod(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+  let expanded =
+    derive_marker_trait::<Pod>(parse_macro_input!(input as DeriveInput));
+
+  proc_macro::TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(Zeroable)]
+pub fn derive_zeroable(
+  input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+  let expanded =
+    derive_marker_trait::<Zeroable>(parse_macro_input!(input as DeriveInput));
+
+  proc_macro::TokenStream::from(expanded)
+}
+
+fn derive_marker_trait<Trait: Derivable>(input: DeriveInput) -> TokenStream {
+  let name = &input.ident;
+
+  let (impl_generics, ty_generics, where_clause) =
+    input.generics.split_for_impl();
+  let span = input.span();
+
+  let fields = if let Data::Struct(DataStruct { fields, .. }) = &input.data {
+    fields
+  } else {
+    return quote! {
+      compile_error!("deriving this trait is only supported for structs");
+    };
+  };
+
+  let trait_ = Trait::ident();
+  if let Err(err) = Trait::check_attributes(&input.attrs) {
+    return err;
+  }
+  let asserts = Trait::struct_asserts(name, fields, span);
+
+  quote! {
+    #asserts
+
+    unsafe impl #impl_generics #trait_ for #name #ty_generics #where_clause {}
+  }
+}
+
+fn get_fields<'a>(
+  fields: &'a Fields,
+) -> Box<dyn Iterator<Item = &'a Field> + 'a> {
+  match fields {
+    Fields::Unit => Box::new(empty()),
+    Fields::Named(FieldsNamed { named, .. }) => Box::new(named.iter()),
+    Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => Box::new(unnamed.iter()),
+  }
+}
+
+fn get_field_types<'a>(
+  fields: &'a Fields,
+) -> impl Iterator<Item = &'a Type> + 'a {
+  get_fields(fields).map(|field| &field.ty)
+}
+
+/// Check that a struct has no padding by asserting that the size of the struct
+/// is equal to the sum of the size of it's fields
+fn generate_assert_no_padding(
+  struct_type: &Ident, fields: &Fields, span: Span,
+) -> TokenStream {
+  let field_types = get_field_types(&fields);
+  let struct_size = quote_spanned!(span => std::mem::size_of::<#struct_type>());
+  let size_sum =
+    quote_spanned!(span => 0 #( + std::mem::size_of::<#field_types>() )*);
+
+  quote_spanned! {span => const _: fn() = || {
+    let _ = core::mem::transmute::<[u8; #struct_size], [u8; #size_sum]>;
+  };}
+}
+
+/// Check that all fields implement Pod
+fn generate_fields_are_trait(
+  fields: &Fields, trait_: TokenStream, span: Span,
+) -> TokenStream {
+  let field_types = get_field_types(&fields);
+  quote_spanned! {span => #(const _: fn() = || {
+      fn assert_impl<T: #trait_>() {}
+      assert_impl::<#field_types>();
+    };)*
+  }
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,85 +1,10 @@
-use proc_macro2::{Ident, Span, TokenStream, TokenTree};
-use quote::{quote, quote_spanned};
-use std::iter::empty;
-use syn::{
-  parse_macro_input, spanned::Spanned, AttrStyle, Attribute, Data, DataStruct,
-  DeriveInput, Field, Fields, FieldsNamed, FieldsUnnamed, Type,
-};
+mod traits;
 
-trait Derivable {
-  fn ident() -> TokenStream;
-  fn struct_asserts(
-    struct_name: &Ident, fields: &Fields, span: Span,
-  ) -> TokenStream;
-  fn check_attributes(_attributes: &[Attribute]) -> Result<(), TokenStream> {
-    Ok(())
-  }
-}
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, spanned::Spanned, Data, DataStruct, DeriveInput};
 
-struct Pod;
-
-impl Derivable for Pod {
-  fn ident() -> TokenStream {
-    quote!(bytemuck::Pod)
-  }
-
-  fn struct_asserts(
-    struct_name: &Ident, fields: &Fields, span: Span,
-  ) -> TokenStream {
-    let assert_no_padding =
-      generate_assert_no_padding(struct_name, fields, span);
-    let assert_fields_are_pod =
-      generate_fields_are_trait(&fields, Self::ident(), span);
-
-    quote!(
-      #assert_no_padding
-      #assert_fields_are_pod
-    )
-  }
-
-  fn check_attributes(attributes: &[Attribute]) -> Result<(), TokenStream> {
-    for attr in attributes {
-      if let (AttrStyle::Outer, Some(outer_ident), Some(inner_ident)) = (
-        &attr.style,
-        attr.path.get_ident(),
-        get_ident_from_stream(attr.tokens.clone()),
-      ) {
-        if outer_ident.to_string() == "repr"
-          && (inner_ident.to_string() == "C"
-            || inner_ident.to_string() == "transparent")
-        {
-          return Ok(());
-        }
-      }
-    }
-
-    Err(quote! {
-      compile_error!("Pod requires the struct to be #[repr(C)] or #[repr(transparent)]");
-    })
-  }
-}
-
-fn get_ident_from_stream(tokens: TokenStream) -> Option<Ident> {
-  match tokens.into_iter().next() {
-    Some(TokenTree::Group(group)) => get_ident_from_stream(group.stream()),
-    Some(TokenTree::Ident(ident)) => Some(ident),
-    _ => None,
-  }
-}
-
-struct Zeroable;
-
-impl Derivable for Zeroable {
-  fn ident() -> TokenStream {
-    quote!(bytemuck::Zeroable)
-  }
-
-  fn struct_asserts(
-    _struct_name: &Ident, fields: &Fields, span: Span,
-  ) -> TokenStream {
-    generate_fields_are_trait(fields, Self::ident(), span)
-  }
-}
+use crate::traits::{Derivable, Pod, TransparentWrapper, Zeroable};
 
 #[proc_macro_derive(Pod)]
 pub fn derive_pod(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -99,7 +24,24 @@ pub fn derive_zeroable(
   proc_macro::TokenStream::from(expanded)
 }
 
+#[proc_macro_derive(TransparentWrapper, attributes(transparent))]
+pub fn derive_transparent(
+  input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+  let expanded = derive_marker_trait::<TransparentWrapper>(parse_macro_input!(
+    input as DeriveInput
+  ));
+
+  proc_macro::TokenStream::from(expanded)
+}
+
 fn derive_marker_trait<Trait: Derivable>(input: DeriveInput) -> TokenStream {
+  derive_marker_trait_inner::<Trait>(input).unwrap_or_else(|err| err)
+}
+
+fn derive_marker_trait_inner<Trait: Derivable>(
+  input: DeriveInput,
+) -> Result<TokenStream, TokenStream> {
   let name = &input.ident;
 
   let (impl_generics, ty_generics, where_clause) =
@@ -109,63 +51,19 @@ fn derive_marker_trait<Trait: Derivable>(input: DeriveInput) -> TokenStream {
   let fields = if let Data::Struct(DataStruct { fields, .. }) = &input.data {
     fields
   } else {
-    return quote! {
+    return Err(quote! {
       compile_error!("deriving this trait is only supported for structs");
-    };
+    });
   };
 
   let trait_ = Trait::ident();
-  if let Err(err) = Trait::check_attributes(&input.attrs) {
-    return err;
-  }
-  let asserts = Trait::struct_asserts(name, fields, span);
+  Trait::check_attributes(&input.attrs)?;
+  let asserts = Trait::struct_asserts(name, fields, &input.attrs, span)?;
+  let trait_params = Trait::generic_params(&input)?;
 
-  quote! {
+  Ok(quote! {
     #asserts
 
-    unsafe impl #impl_generics #trait_ for #name #ty_generics #where_clause {}
-  }
-}
-
-fn get_fields<'a>(
-  fields: &'a Fields,
-) -> Box<dyn Iterator<Item = &'a Field> + 'a> {
-  match fields {
-    Fields::Unit => Box::new(empty()),
-    Fields::Named(FieldsNamed { named, .. }) => Box::new(named.iter()),
-    Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => Box::new(unnamed.iter()),
-  }
-}
-
-fn get_field_types<'a>(
-  fields: &'a Fields,
-) -> impl Iterator<Item = &'a Type> + 'a {
-  get_fields(fields).map(|field| &field.ty)
-}
-
-/// Check that a struct has no padding by asserting that the size of the struct
-/// is equal to the sum of the size of it's fields
-fn generate_assert_no_padding(
-  struct_type: &Ident, fields: &Fields, span: Span,
-) -> TokenStream {
-  let field_types = get_field_types(&fields);
-  let struct_size = quote_spanned!(span => std::mem::size_of::<#struct_type>());
-  let size_sum =
-    quote_spanned!(span => 0 #( + std::mem::size_of::<#field_types>() )*);
-
-  quote_spanned! {span => const _: fn() = || {
-    let _ = core::mem::transmute::<[u8; #struct_size], [u8; #size_sum]>;
-  };}
-}
-
-/// Check that all fields implement Pod
-fn generate_fields_are_trait(
-  fields: &Fields, trait_: TokenStream, span: Span,
-) -> TokenStream {
-  let field_types = get_field_types(&fields);
-  quote_spanned! {span => #(const _: fn() = || {
-      fn assert_impl<T: #trait_>() {}
-      assert_impl::<#field_types>();
-    };)*
-  }
+    unsafe impl #impl_generics #trait_ #trait_params for #name #ty_generics #where_clause {}
+  })
 }

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -125,9 +125,7 @@ impl Derivable for TransparentWrapper {
   }
 }
 
-fn get_struct_fields<'a>(
-  input: &'a DeriveInput,
-) -> Result<&'a Fields, &'static str> {
+fn get_struct_fields(input: &DeriveInput) -> Result<&Fields, &'static str> {
   if let Data::Struct(DataStruct { fields, .. }) = &input.data {
     Ok(fields)
   } else {

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -1,0 +1,217 @@
+use proc_macro2::{Ident, Span, TokenStream, TokenTree};
+use quote::{quote, quote_spanned, ToTokens};
+use std::iter::empty;
+use syn::{
+  AttrStyle, Attribute, Data, DataStruct, DeriveInput, Field, Fields,
+  FieldsNamed, FieldsUnnamed, Type,
+};
+
+pub trait Derivable {
+  fn ident() -> TokenStream;
+  fn generic_params(_input: &DeriveInput) -> Result<TokenStream, TokenStream> {
+    Ok(quote!())
+  }
+  fn struct_asserts(
+    struct_name: &Ident, fields: &Fields, attributes: &[Attribute], span: Span,
+  ) -> Result<TokenStream, TokenStream>;
+  fn check_attributes(_attributes: &[Attribute]) -> Result<(), TokenStream> {
+    Ok(())
+  }
+}
+
+pub struct Pod;
+
+impl Derivable for Pod {
+  fn ident() -> TokenStream {
+    quote!(::bytemuck::Pod)
+  }
+
+  fn struct_asserts(
+    struct_name: &Ident, fields: &Fields, _attributes: &[Attribute], span: Span,
+  ) -> Result<TokenStream, TokenStream> {
+    let assert_no_padding =
+      generate_assert_no_padding(struct_name, fields, span);
+    let assert_fields_are_pod =
+      generate_fields_are_trait(&fields, Self::ident(), span);
+
+    Ok(quote!(
+      #assert_no_padding
+      #assert_fields_are_pod
+    ))
+  }
+
+  fn check_attributes(attributes: &[Attribute]) -> Result<(), TokenStream> {
+    let repr = get_repr(attributes);
+    match repr.as_ref().map(|repr| repr.as_str()) {
+      Some("C") => Ok(()),
+      Some("transparent") => Ok(()),
+      _ => Err(quote! {
+        compile_error!("Pod requires the struct to be #[repr(C)] or #[repr(transparent)]");
+      }),
+    }
+  }
+}
+
+pub struct Zeroable;
+
+impl Derivable for Zeroable {
+  fn ident() -> TokenStream {
+    quote!(::bytemuck::Zeroable)
+  }
+
+  fn struct_asserts(
+    _struct_name: &Ident, fields: &Fields, _attributes: &[Attribute],
+    span: Span,
+  ) -> Result<TokenStream, TokenStream> {
+    Ok(generate_fields_are_trait(fields, Self::ident(), span))
+  }
+}
+
+pub struct TransparentWrapper;
+
+impl TransparentWrapper {
+  fn get_wrapper_type(
+    attributes: &[Attribute], fields: &Fields,
+  ) -> Option<TokenStream> {
+    let transparent_param = get_simple_attr(attributes, "transparent");
+    transparent_param.map(|ident| ident.to_token_stream()).or_else(|| {
+      let mut types = get_field_types(fields);
+      let first_type = types.next();
+      if let Some(_) = types.next() {
+        // can't guess param type if there is more than one field
+        return None;
+      } else {
+        first_type.map(|ty| ty.to_token_stream())
+      }
+    })
+  }
+}
+
+impl Derivable for TransparentWrapper {
+  fn ident() -> TokenStream {
+    quote!(::bytemuck::TransparentWrapper)
+  }
+
+  fn struct_asserts(
+    _struct_name: &Ident, fields: &Fields, attributes: &[Attribute],
+    _span: Span,
+  ) -> Result<TokenStream, TokenStream> {
+    let wrapped_type = match Self::get_wrapper_type(attributes, fields) {
+      Some(wrapped_type) => wrapped_type.to_string(),
+      None => return Err(quote!()), /* other code will already reject this
+                                     * derive */
+    };
+    let mut wrapped_fields = get_fields(fields)
+      .filter(|field| field.ty.to_token_stream().to_string() == wrapped_type);
+    if let None = wrapped_fields.next() {
+      return Err(quote! {
+        compile_error!("TransparentWrapper must have one field of the wrapped type");
+      });
+    };
+    if let Some(_) = wrapped_fields.next() {
+      Err(quote! {
+        compile_error!("TransparentWrapper can only have one field of the wrapped type");
+      })
+    } else {
+      Ok(quote!())
+    }
+  }
+
+  fn check_attributes(attributes: &[Attribute]) -> Result<(), TokenStream> {
+    let repr = get_repr(attributes);
+
+    match repr.as_ref().map(|repr| repr.as_str()) {
+      Some("transparent") => Ok(()),
+      _ => Err(quote! {
+        compile_error!("TransparentWrapper requires the struct to be #[repr(transparent)]");
+      }),
+    }
+  }
+
+  fn generic_params(input: &DeriveInput) -> Result<TokenStream, TokenStream> {
+    let fields = if let Data::Struct(DataStruct { fields, .. }) = &input.data {
+      fields
+    } else {
+      return Err(quote! {
+        compile_error!("deriving this trait is only supported for structs");
+      });
+    };
+
+    Self::get_wrapper_type(&input.attrs, fields).map(|ty| quote!(<#ty>))
+      .ok_or_else(|| quote! {
+        compile_error!("when deriving TransparentWrapper for a struct with more than one field you need to specify the transparent field using #[transparent(T)]");
+      })
+  }
+}
+
+fn get_fields<'a>(
+  fields: &'a Fields,
+) -> Box<dyn Iterator<Item = &'a Field> + 'a> {
+  match fields {
+    Fields::Unit => Box::new(empty()),
+    Fields::Named(FieldsNamed { named, .. }) => Box::new(named.iter()),
+    Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => Box::new(unnamed.iter()),
+  }
+}
+
+fn get_field_types<'a>(
+  fields: &'a Fields,
+) -> impl Iterator<Item = &'a Type> + 'a {
+  get_fields(fields).map(|field| &field.ty)
+}
+
+/// Check that a struct has no padding by asserting that the size of the struct
+/// is equal to the sum of the size of it's fields
+fn generate_assert_no_padding(
+  struct_type: &Ident, fields: &Fields, span: Span,
+) -> TokenStream {
+  let field_types = get_field_types(&fields);
+  let struct_size = quote_spanned!(span => std::mem::size_of::<#struct_type>());
+  let size_sum =
+    quote_spanned!(span => 0 #( + std::mem::size_of::<#field_types>() )*);
+
+  quote_spanned! {span => const _: fn() = || {
+    let _ = core::mem::transmute::<[u8; #struct_size], [u8; #size_sum]>;
+  };}
+}
+
+/// Check that all fields implement Pod
+fn generate_fields_are_trait(
+  fields: &Fields, trait_: TokenStream, span: Span,
+) -> TokenStream {
+  let field_types = get_field_types(&fields);
+  quote_spanned! {span => #(const _: fn() = || {
+      fn assert_impl<T: #trait_>() {}
+      assert_impl::<#field_types>();
+    };)*
+  }
+}
+
+fn get_ident_from_stream(tokens: TokenStream) -> Option<Ident> {
+  match tokens.into_iter().next() {
+    Some(TokenTree::Group(group)) => get_ident_from_stream(group.stream()),
+    Some(TokenTree::Ident(ident)) => Some(ident),
+    _ => None,
+  }
+}
+
+/// get a simple #[foo(bar)] attribute, returning "bar"
+fn get_simple_attr(attributes: &[Attribute], attr_name: &str) -> Option<Ident> {
+  for attr in attributes {
+    if let (AttrStyle::Outer, Some(outer_ident), Some(inner_ident)) = (
+      &attr.style,
+      attr.path.get_ident(),
+      get_ident_from_stream(attr.tokens.clone()),
+    ) {
+      if outer_ident.to_string() == attr_name {
+        return Some(inner_ident.clone());
+      }
+    }
+  }
+
+  None
+}
+
+fn get_repr(attributes: &[Attribute]) -> Option<String> {
+  get_simple_attr(attributes, "repr").map(|ident| ident.to_string())
+}

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -166,9 +166,9 @@ fn generate_assert_no_padding(
   struct_type: &Ident, fields: &Fields, span: Span,
 ) -> TokenStream {
   let field_types = get_field_types(&fields);
-  let struct_size = quote_spanned!(span => std::mem::size_of::<#struct_type>());
+  let struct_size = quote_spanned!(span => core::mem::size_of::<#struct_type>());
   let size_sum =
-    quote_spanned!(span => 0 #( + std::mem::size_of::<#field_types>() )*);
+    quote_spanned!(span => 0 #( + core::mem::size_of::<#field_types>() )*);
 
   quote_spanned! {span => const _: fn() = || {
     let _ = core::mem::transmute::<[u8; #struct_size], [u8; #size_sum]>;

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -1,10 +1,6 @@
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
 use quote::{quote, quote_spanned, ToTokens};
-use std::iter::empty;
-use syn::{
-  AttrStyle, Attribute, Data, DataStruct, DeriveInput, Field, Fields,
-  FieldsNamed, FieldsUnnamed, Type,
-};
+use syn::{AttrStyle, Attribute, Data, DataStruct, DeriveInput, Fields, Type};
 
 pub trait Derivable {
   fn ident() -> TokenStream;
@@ -100,7 +96,8 @@ impl Derivable for TransparentWrapper {
       Some(wrapped_type) => wrapped_type.to_string(),
       None => return Err(""), /* other code will already reject this derive */
     };
-    let mut wrapped_fields = get_fields(fields)
+    let mut wrapped_fields = fields
+      .iter()
       .filter(|field| field.ty.to_token_stream().to_string() == wrapped_type);
     if let None = wrapped_fields.next() {
       return Err("TransparentWrapper must have one field of the wrapped type");
@@ -135,20 +132,10 @@ impl Derivable for TransparentWrapper {
   }
 }
 
-fn get_fields<'a>(
-  fields: &'a Fields,
-) -> Box<dyn Iterator<Item = &'a Field> + 'a> {
-  match fields {
-    Fields::Unit => Box::new(empty()),
-    Fields::Named(FieldsNamed { named, .. }) => Box::new(named.iter()),
-    Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => Box::new(unnamed.iter()),
-  }
-}
-
 fn get_field_types<'a>(
   fields: &'a Fields,
 ) -> impl Iterator<Item = &'a Type> + 'a {
-  get_fields(fields).map(|field| &field.ty)
+  fields.iter().map(|field| &field.ty)
 }
 
 /// Check that a struct has no padding by asserting that the size of the struct

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -98,7 +98,7 @@ impl Derivable for TransparentWrapper {
     let fields = get_struct_fields(input)?;
     let wrapped_type = match Self::get_wrapper_type(&input.attrs, fields) {
       Some(wrapped_type) => wrapped_type.to_string(),
-      None => return Err(""), /* other code will already reject this derive */
+      None => unreachable!(), /* other code will already reject this derive */
     };
     let mut wrapped_fields = fields
       .iter()

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -1,12 +1,18 @@
 #![allow(dead_code)]
 
 use bytemuck_derive::{Pod, TransparentWrapper, Zeroable};
+use std::marker::PhantomData;
 
 #[derive(Copy, Clone, Pod, Zeroable)]
 #[repr(C)]
 struct Test {
   a: u16,
   b: u16,
+}
+
+#[derive(Zeroable)]
+struct ZeroGeneric<T: bytemuck::Zeroable> {
+  a: T,
 }
 
 #[derive(TransparentWrapper)]
@@ -18,7 +24,7 @@ struct TransparentSingle {
 #[derive(TransparentWrapper)]
 #[repr(transparent)]
 #[transparent(u16)]
-struct TransparentWithZeroSized {
+struct TransparentWithZeroSized<T> {
   a: u16,
-  b: (),
+  b: PhantomData<T>,
 }

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -1,0 +1,8 @@
+use bytemuck_derive::{Pod, Zeroable};
+
+#[derive(Copy, Clone, Pod, Zeroable)]
+#[repr(C)]
+struct Test {
+  a: u16,
+  b: u16,
+}

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -1,8 +1,24 @@
-use bytemuck_derive::{Pod, Zeroable};
+#![allow(dead_code)]
+
+use bytemuck_derive::{Pod, TransparentWrapper, Zeroable};
 
 #[derive(Copy, Clone, Pod, Zeroable)]
 #[repr(C)]
 struct Test {
   a: u16,
   b: u16,
+}
+
+#[derive(TransparentWrapper)]
+#[repr(transparent)]
+struct TransparentSingle {
+  a: u16,
+}
+
+#[derive(TransparentWrapper)]
+#[repr(transparent)]
+#[transparent(u16)]
+struct TransparentWithZeroSized {
+  a: u16,
+  b: (),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ mod transparent;
 pub use transparent::*;
 
 #[cfg(feature = "derive")]
-pub use bytemuck_derive::{Zeroable, Pod};
+pub use bytemuck_derive::{Zeroable, Pod, TransparentWrapper};
 
 /*
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,9 @@ pub use offset_of::*;
 mod transparent;
 pub use transparent::*;
 
+#[cfg(feature = "derive")]
+pub use bytemuck_derive::{Zeroable, Pod};
+
 /*
 
 Note(Lokathor): We've switched all of the `unwrap` to `match` because there is

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,0 +1,10 @@
+#![cfg(feature = "derive")]
+
+use bytemuck::{Zeroable, Pod};
+
+#[derive(Copy, Clone, Pod, Zeroable)]
+#[repr(C)]
+struct Test {
+  a: u16,
+  b: u16,
+}

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,10 +1,25 @@
 #![cfg(feature = "derive")]
+#![allow(dead_code)]
 
-use bytemuck::{Zeroable, Pod};
+use bytemuck::{Zeroable, Pod, TransparentWrapper};
 
 #[derive(Copy, Clone, Pod, Zeroable)]
 #[repr(C)]
 struct Test {
   a: u16,
   b: u16,
+}
+
+#[derive(TransparentWrapper)]
+#[repr(transparent)]
+struct TransparentSingle {
+  a: u16,
+}
+
+#[derive(TransparentWrapper)]
+#[repr(transparent)]
+#[transparent(u16)]
+struct TransparentWithZeroSized {
+  a: u16,
+  b: ()
 }


### PR DESCRIPTION
Adds derive macros for `Zeroable` and `Pod` for structs.

The macro is exported behind the `derive` feature flag (same way as serde does)

- The `Zeroable` macro checks that all fields are `Zeroable`.
- The `Pod` macro checks that all fields are `Pod`, there is no padding bytes and that the struct is `#[repr(C)]` or `#[repr(packed)]`

This currently only supports deriving for structs, deriving `Zeroable` would be possible in the future.

Fixes #4 