### PR TITLE
Fix Pod derive to use explicit absolute path to 'core'

### DIFF
--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -150,12 +150,12 @@ fn generate_assert_no_padding(
 
   let field_types = get_field_types(&fields);
   let struct_size =
-    quote_spanned!(span => core::mem::size_of::<#struct_type>());
+    quote_spanned!(span => ::core::mem::size_of::<#struct_type>());
   let size_sum =
-    quote_spanned!(span => 0 #( + core::mem::size_of::<#field_types>() )*);
+    quote_spanned!(span => 0 #( + ::core::mem::size_of::<#field_types>() )*);
 
   Ok(quote_spanned! {span => const _: fn() = || {
-    let _ = core::mem::transmute::<[u8; #struct_size], [u8; #size_sum]>;
+    let _ = ::core::mem::transmute::<[u8; #struct_size], [u8; #size_sum]>;
   };})
 }
 


### PR DESCRIPTION
On the `main` branch, if `#[derive(Pod)]` is used in a module that has a sub-module named `core` (like I have in my project), Rust will incorrectly attempt to resolve symbols relative to that module instead of the `core` crate.

Small repro:

```rust
mod core {}

use bytemuck_derive::{Zeroable, Pod};

#[derive(Zeroable, Pod)]
struct Foo {
    x: i32,
}
```

It's good practice to use absolute references like this in macros for that reason.