### PR TITLE
(WIP) Improve error messages from derive macros

### DIFF
--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -210,17 +210,16 @@ fn generate_assert_no_padding(
   input: &DeriveInput,
 ) -> Result<TokenStream, &'static str> {
   let struct_type = &input.ident;
-  let span = input.span();
+  let span = input.ident.span();
   let fields = get_struct_fields(input)?;
 
   let field_types = get_field_types(&fields);
-  let struct_size =
-    quote_spanned!(span => ::core::mem::size_of::<#struct_type>());
   let size_sum =
     quote_spanned!(span => 0 #( + ::core::mem::size_of::<#field_types>() )*);
 
   Ok(quote_spanned! {span => const _: fn() = || {
-    let _ = ::core::mem::transmute::<[u8; #struct_size], [u8; #size_sum]>;
+    struct TypeWithoutPadding([u8; #size_sum]);
+    let _ = ::core::mem::transmute::<#struct_type, TypeWithoutPadding>;
   };})
 }
 


### PR DESCRIPTION
Fixes to help close #4.

Error messages from padding for deriving `Pod` before looked like this:

![before](https://user-images.githubusercontent.com/654598/90988573-93e6bd80-e548-11ea-92e3-a023d2207d1e.png)

...and now they look like this, which is a small improvement:

![after](https://user-images.githubusercontent.com/654598/90996538-e5587200-e573-11ea-9447-d00c91cb97a8.png)

I couldn't figure out a way to make the second type have a nicer name, but having any name at all can hint at what's going wrong I guess.