### PR TITLE
Mark playground as using all-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ bytemuck_derive = { version = "1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true
+
+[package.metadata.playground]
+all-features = true


### PR DESCRIPTION
`bytemuck` is available on the playground because it is a dependency of... something. (Not sure what's pulling it in actually but whatever). It's an older version (1.2.0) but eventually that will *probably* update.

It would be nice to have at least `derive` available, and `bytemuck` is lightweight enough that there's no reason for all features not to be available on the playground.

This adds a metadata entry to the Cargo.toml that enables this.

(That said, I don't actually know if this works for crates pulled into the playground as transitive deps. This is just what I did for `rusqlite` to make it work... but `rusqlite` is on the playground because it's in the cookbook. Honestly though, a cookbook entry for `bytemuck` might not be out of place, since most people would assume you need to use unsafe code for those operations)