### PR TITLE
Add more tests, overhaul CI, and fix plug soundness hole in `bytemuck::offset_of!`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,35 +4,85 @@ on:
   push: {}
   pull_request: {}
 
+env:
+  RUST_BACKTRACE: 1
+
 jobs:
-  build_test_no_features:
-    runs-on: ubuntu-latest
+  test:
+    name: Test Rust ${{ matrix.rust }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust:
-        # 1.34 doesn't support the alloc feature! (1.36 or later)
-        - { toolchain: 1.34.0, extra_args: "" }
-        # Stable and later support all of our features.
-        - { toolchain: stable, extra_args: "" }
-        - { toolchain: stable, extra_args: "--all-features" }
-        - { toolchain: beta, extra_args: "" }
-        - { toolchain: beta, extra_args: "--all-features" }
-        - { toolchain: nightly, extra_args: "" }
-        - { toolchain: nightly, extra_args: "--all-features" }
+        include:
+        # versions (all on linux-x86_64)
+        - { rust: '1.34.0', os: ubuntu-latest }
+        - { rust: stable, os: ubuntu-latest }
+        - { rust: beta, os: ubuntu-latest }
+        - { rust: nightly, os: ubuntu-latest }
+        # non-linux platforms (ones which don't require `cross`)
+        - { rust: stable, os: macos-latest }
+        - { rust: stable, os: windows-latest }
+        - { rust: stable-x86_64-gnu, os: windows-latest }
+        - { rust: stable-i686-msvc, os: windows-latest }
+        - { rust: stable-i686-gnu, os: windows-latest }
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:
-        rust-version: ${{ matrix.rust.toolchain }}
-    - uses: actions/checkout@v1
-    - uses: actions-rs/cargo@v1
+        rust-version: ${{ matrix.rust }}
+    - uses: actions/checkout@v2
+    - run: cargo test --verbose --no-default-features
+    - run: cargo test --verbose --all-features
+    - run: cargo test --verbose --manifest-path=derive/Cargo.toml --all-features
+
+  cross-test:
+    name: Test on ${{ matrix.target }} with cross
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # note: the mips targets are here so that we have big-endian coverage (both 32bit and 64bit)
+        target: [i686-unknown-linux-gnu, mips-unknown-linux-gnu, mips64-unknown-linux-gnuabi64]
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+    - uses: actions/checkout@v2
+    - run: cargo install cross
+    - run: cross test --verbose --target=${{ matrix.target }} --no-default-features
+    - run: cross test --verbose --target=${{ matrix.target }} --all-features
+    - run: cross test --verbose --target=${{ matrix.target }} --manifest-path=derive/Cargo.toml --all-features
+
+  miri-test:
+    name: Test with miri
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hecrj/setup-rust-action@v1
       with:
-        toolchain: ${{ matrix.rust.toolchain }}
-        command: test
-        args: ${{ matrix.rust.extra_args }}
-    - name: Switch to Derive Folder
-      run: cd derive
-    - uses: actions-rs/cargo@v1
+        rust-version: nightly
+        components: miri
+    - run: cargo miri test --verbose --no-default-features
+    - run: cargo miri test --verbose --all-features
+    - run: cargo miri test --verbose --manifest-path=derive/Cargo.toml --all-features
+
+  sanitizer-test:
+    name: Test with -Zsanitizer=${{ matrix.sanitizer }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, memory, leak]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: hecrj/setup-rust-action@v1
       with:
-        toolchain: ${{ matrix.rust.toolchain }}
-        command: test
-        args: ${{ matrix.rust.extra_args }}
+        rust-version: nightly
+        components: rust-src
+    - name: Test with sanitizer
+      env:
+        RUSTFLAGS: -Zsanitizer=${{ matrix.sanitizer }}
+        RUSTDOCFLAGS: -Zsanitizer=${{ matrix.sanitizer }}
+        ASAN_OPTIONS: detect_stack_use_after_return=1
+        # Asan's leak detection occasionally complains about some small leaks if
+        # backtraces are captured.
+        RUST_BACKTRACE: 0
+      run: |
+        cargo test -Zbuild-std --verbose --target=x86_64-unknown-linux-gnu --no-default-features
+        cargo test -Zbuild-std --verbose --target=x86_64-unknown-linux-gnu --all-features
+        cargo test -Zbuild-std --verbose --target=x86_64-unknown-linux-gnu --manifest-path=derive/Cargo.toml --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,7 @@ jobs:
       with:
         rust-version: nightly
         components: miri
+    - uses: actions/checkout@v2
     - run: cargo miri test --verbose --no-default-features
     - run: cargo miri test --verbose --all-features
     - run: cargo miri test --verbose --manifest-path=derive/Cargo.toml --all-features
@@ -88,7 +89,15 @@ jobs:
         # Asan's leak detection occasionally complains about some small leaks if
         # backtraces are captured.
         RUST_BACKTRACE: 0
+      # We don't run `derive`'s unit tests here the way we do elsewhere (for
+      # example, in `miri-test` above), as at the moment we can't easily build
+      # the `proc_macro` runtime with sanitizers on. IIUC doing this would
+      # require a custom rustc build, and... lol nope.
+      #
+      # This would mean only part of the code running under the sanitizer would
+      # actually include the sanitizer's checks, which is a recipe for false
+      # positives, so we just skip it, the generated code is what we care
+      # about anyway.
       run: |
         cargo test -Zbuild-std --verbose --target=x86_64-unknown-linux-gnu --no-default-features
         cargo test -Zbuild-std --verbose --target=x86_64-unknown-linux-gnu --all-features
-        cargo test -Zbuild-std --verbose --target=x86_64-unknown-linux-gnu --manifest-path=derive/Cargo.toml --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,9 +13,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # it's a little tempting to use `matrix` to do a cartesian product with
+        # our `--feature` config here, but doing so will be very slow, as the
+        # free tier only supports up to 20 job runners at a time.
         include:
         # versions (all on linux-x86_64)
-        - { rust: '1.34.0', os: ubuntu-latest }
+        - { rust: 1.34.0, os: ubuntu-latest }
         - { rust: stable, os: ubuntu-latest }
         - { rust: beta, os: ubuntu-latest }
         - { rust: nightly, os: ubuntu-latest }
@@ -30,9 +33,12 @@ jobs:
       with:
         rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@v2
+    - run: cargo test --verbose
     - run: cargo test --verbose --no-default-features
     - run: cargo test --verbose --all-features
+      if: matrix.rust != '1.34.0'
     - run: cargo test --verbose --manifest-path=derive/Cargo.toml --all-features
+      if: matrix.rust != '1.34.0'
 
   cross-test:
     name: Test on ${{ matrix.target }} with cross

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@ pub fn cast_ref<A: Pod, B: Pod>(a: &A) -> &B {
   }
 }
 
-/// Cast `&[T]` into `&[U]`.
+/// Cast `&[A]` into `&[B]`.
 ///
 /// ## Panics
 ///
@@ -376,7 +376,7 @@ pub fn try_cast_mut<A: Pod, B: Pod>(a: &mut A) -> Result<&mut B, PodCastError> {
   }
 }
 
-/// Try to convert `&[T]` into `&[U]` (possibly with a change in length).
+/// Try to convert `&[A]` into `&[B]` (possibly with a change in length).
 ///
 /// * `input.as_ptr() as usize == output.as_ptr() as usize`
 /// * `input.len() * size_of::<A>() == output.len() * size_of::<B>()`
@@ -411,7 +411,7 @@ pub fn try_cast_slice<A: Pod, B: Pod>(a: &[A]) -> Result<&[B], PodCastError> {
   }
 }
 
-/// Try to convert `&mut [T]` into `&mut [U]` (possibly with a change in
+/// Try to convert `&mut [A]` into `&mut [B]` (possibly with a change in
 /// length).
 ///
 /// As [`try_cast_slice`], but `&mut`.

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -17,16 +17,6 @@
 /// type used is `repr(Rust)` then they're *not* fixed across compilations or
 /// compilers.
 ///
-/// **CAUTION:** It is **unsound** to use this macro with a `repr(packed)` type.
-/// Currently this will give a warning, and in the future it will become a hard
-/// error.
-/// * See [rust-lang/rust#27060](https://github.com/rust-lang/rust/issues/27060)
-///   for more info and for status updates.
-/// * Once this issue is resolved, a future version of this crate will use
-///   `raw_ref` to correct the issue. For the duration of the `1.x` version of
-///   this crate it will be an on-by-default cargo feature (to maintain minimum
-///   rust version support).
-///
 /// ## Examples
 ///
 /// ### 3-arg Usage
@@ -64,20 +54,77 @@
 /// assert_eq!(offset_of!(Vertex, loc), 0);
 /// assert_eq!(offset_of!(Vertex, color), 12);
 /// ```
+///
+/// # Usage with `#[repr(packed)]` structs
+///
+/// Attempting to compute the offset of a `#[repr(packed)]` struct with
+/// `bytemuck::offset_of!` requires an `unsafe` block. We hope to relax this in
+/// the future, but currently it is required to work around a soundness hole in
+/// Rust (See [rust-lang/rust#27060]).
+///
+/// [rust-lang/rust#27060]: https://github.com/rust-lang/rust/issues/27060
+///
+/// <p style="background:rgba(255,181,77,0.16);padding:0.75em;">
+/// <strong>Warning:</strong> This is only true for versions of bytemuck > 1.4.0.
+/// Previous versions of
+/// <code style="background:rgba(41,24,0,0.1);">bytemuck::offset_of!</code>
+/// will only emit a warning when used on the field of a packed struct in safe code,
+/// which can lead to unsoundness.
+/// </p>
+///
+/// For example, the following will fail to compile:
+///
+/// ```compile_fail
+/// #[repr(C, packed)]
+/// #[derive(Default)]
+/// struct Example {
+///   field: u32,
+/// }
+/// // Doesn't compile:
+/// let _offset = bytemuck::offset_of!(Example, field);
+/// ```
+///
+/// While the error message this generates will mention the
+/// `safe_packed_borrows` lint, the macro will still fail to compile even if
+/// that lint is `#[allow]`ed:
+///
+/// ```compile_fail
+/// # #[repr(C, packed)] #[derive(Default)] struct Example { field: u32 }
+/// // Still doesn't compile:
+/// #[allow(safe_packed_borrows)] {
+///   let _offset = bytemuck::offset_of!(Example, field);
+/// }
+/// ```
+///
+/// This *can* be worked around by using `unsafe`, but it is only sound to do so
+/// if you can guarantee that taking a reference to the field is sound.
+///
+/// In practice, this means it only works for fields of align(1) types, or if
+/// you know the field's offset in advance (defeating the point of `offset_of`)
+/// and can prove that the struct's alignment and the field's offset are enough
+/// to prove the field's alignment.
+///
+/// Once the `raw_ref` macros are available, a future version of this crate will
+/// use them to lift the limitations of packed structs. For the duration of the
+/// `1.x` version of this crate that will be behind an on-by-default cargo
+/// feature (to maintain minimum rust version support).
 #[macro_export]
 macro_rules! offset_of {
   ($instance:expr, $Type:path, $field:tt) => {{
-    // This helps us guard against field access going through a Deref impl.
-    #[allow(clippy::unneeded_field_pattern)]
-    let $Type { $field: _, .. };
-    let reference: &$Type = &$instance;
-    let address = reference as *const _ as usize;
-    let field_pointer = &reference.$field as *const _ as usize;
-    // These asserts/unwraps are compiled away at release, and defend against
-    // the case where somehow a deref impl is still invoked.
-    let result = field_pointer.checked_sub(address).unwrap();
-    assert!(result <= $crate::__core::mem::size_of::<$Type>());
-    result
+    #[forbid(safe_packed_borrows)]
+    {
+      // This helps us guard against field access going through a Deref impl.
+      #[allow(clippy::unneeded_field_pattern)]
+      let $Type { $field: _, .. };
+      let reference: &$Type = &$instance;
+      let address = reference as *const _ as usize;
+      let field_pointer = &reference.$field as *const _ as usize;
+      // These asserts/unwraps are compiled away at release, and defend against
+      // the case where somehow a deref impl is still invoked.
+      let result = field_pointer.checked_sub(address).unwrap();
+      assert!(result <= $crate::__core::mem::size_of::<$Type>());
+      result
+    }
   }};
   ($Type:path, $field:tt) => {{
     $crate::offset_of!(<$Type as Default>::default(), $Type, $field)


### PR DESCRIPTION
I gave you a heads up in discord about this. Basically, I had a bunch of 80% finished work in `git stash`es, since I keep meaning to give bytemuck a bit more attention. Anyway I found some time and cleaned them up.

... Which is to say, this PR is a bit of a hodge-podgey mess of things that are useful but not meaningfully related. It's not *too* big, but it's also not ideal to review.

That said, what's here is pretty nice maybe? In order of smallest to largest:

1. (first commit) Some minor doc fixing I noticed a while ago where you call types `T` and `U` but the function takes `A` and `B` type params. IMO in an ideal world these would be `From` and `To` but at a minimum the docs should use the right names.

2. (third commit) Add some more unit tests. I ran a coverage scan of `bytemuck` at one point and it only has like 50%. Many of it's functions are very small and unlikely to hold bugs, but it doesn't really feel acceptable to have a crate with so much unsafe to have low coverage. Eventually I'll probably add more.

3. (fourth commit) Totally rewrite the CI. I was concervative in what I forced on you here, but now it supports:
    - All the same stuff it was doing, e.g. test on 1.34.0, stable, beta, nightly on linux-x86_64.
    - Direct (non-`cross`) tests on `macOS-x86_64`, `windows-{x86_64,i686}-{msvc,gnu}`.
    - `cross`-based tests on `linux-i686`, and 32-bit/64-bit mips (mips is obscure but is a big endian system which doesn't cause much trouble when run in `cross` *cough unlike ppc cough*)
    - Running tests under `miri`, `asan`, `msan`, and `lsan`.

    - I didn't add anything that might be a little controversial, like lint/fmt/coverage/doc-check, but you can take a look at what I considered here: https://gist.github.com/thomcc/4d37f0ae675b3a2cba9ca5a7e2ba8baa. Of these IMO doc check is the most useful, since it makes it easier to be confident about cross-referencing in the docs.

	- (Oh and ofc I totally eyeballed this and can't test it locally so I'll probably have to add some followup commits to ensure it compiles. As you do).

4. (third commit) Fix the soundness hole in `bytemuck::offset_of!`, and overhaul it's docs. This is done using `#[forbid(safe_packed_borrows)]` inside the macro body. This works at least back to the MSRV, didn't check any further.

    - It comes with `compile_fail` tests (to ensure soundness), and an explanation that basically boils down to "No, this doesn't just mean you should wrap the macro in `unsafe`".

    - This is p. straightforward, but probably harder to review than the others since it's an API change that impacts safety.

