### PR TITLE
Adds re-exporting macros and crate renaming support;

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ extern_crate_alloc = []
 extern_crate_std = ["extern_crate_alloc"]
 zeroable_maybe_uninit = []
 derive = ["bytemuck_derive"]
+proc-macro-crate = ["bytemuck_derive/proc-macro-crate"]
 
 [dependencies]
 # use the upper line for testing against bytemuck_derive changes, if any

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
 exclude = ["/pedantic.bat"]
 
+[workspace]
+members = ["derive"]
+
 [features]
 # Note: Yeah these names are non-standard, we'll fix it in v2 some day maybe
 extern_crate_alloc = []
@@ -20,8 +23,8 @@ derive = ["bytemuck_derive"]
 
 [dependencies]
 # use the upper line for testing against bytemuck_derive changes, if any
-#bytemuck_derive = { version = "1.0.1-alpha.0", path = "derive", optional = true }
-bytemuck_derive = { version = "1", optional = true }
+bytemuck_derive = { version = "1.0.2-alpha.0", path = "derive", optional = true }
+# bytemuck_derive = { version = "1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,7 +18,8 @@ proc-macro = true
 syn = "1"
 quote = "1"
 proc-macro2 = "1"
-proc-macro-crate = "1"
+proc-macro-crate.version = "1"
+proc-macro-crate.optional = true
 
 [dev-dependencies]
 bytemuck = "1.2"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,8 +18,7 @@ proc-macro = true
 syn = "1"
 quote = "1"
 proc-macro2 = "1"
-proc-macro-crate.version = "1"
-proc-macro-crate.optional = true
+proc-macro-crate = { version = "1", optional = true }
 
 [dev-dependencies]
 bytemuck = "1.2"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro = true
 syn = "1"
 quote = "1"
 proc-macro2 = "1"
+proc-macro-crate = "1"
 
 [dev-dependencies]
 bytemuck = "1.2"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -177,3 +177,34 @@ fn derive_marker_trait_inner<Trait: Derivable>(
     }
   })
 }
+
+#[test]
+fn test_derve_output() {
+  let input = quote!(
+    #[repr(C)]
+    #[derive(Copy, Clone, Contiguous)]
+    struct Foo {
+      bar: u32,
+    }
+  );
+  let input = syn::parse_str::<DeriveInput>(&input.to_string()[..])
+    .expect("syntax error");
+  /* let input = DeriveInput {
+    attrs: vec![],
+    vis: syn::Visibility::Public(syn::VisPublic {
+      pub_token: syn::token::Pub { ..Default::default() },
+    }),
+    ident: syn::Ident::new("foo", proc_macro2::Span::call_site()),
+    data: syn::Data::Struct(syn::DataStruct {
+      fields: syn::Fields::Unit,
+      semi_token: None,
+      struct_token: syn::token::Struct { ..Default::default() },
+    }),
+    generics: syn::Generics { ..Default::default() },
+  }; */
+  let result = derive_marker_trait::<Pod>(input);
+  println!("result:\n {}", result.to_string());
+  assert!(result
+    .to_string()
+    .contains("unsafe impl bytemuck :: Pod for Foo { }"));
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -192,5 +192,5 @@ fn test_derive_output() {
   let result = derive_marker_trait::<Pod>(input);
   assert!(result
     .to_string()
-    .contains("unsafe impl :: bytemuck :: Pod for Foo { }"));
+    .contains("unsafe impl bytemuck :: Pod for Foo { }"));
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -179,7 +179,7 @@ fn derive_marker_trait_inner<Trait: Derivable>(
 }
 
 #[test]
-fn test_derve_output() {
+fn test_derive_output() {
   let input = quote!(
     #[repr(C)]
     #[derive(Copy, Clone, Contiguous)]
@@ -189,22 +189,8 @@ fn test_derve_output() {
   );
   let input = syn::parse_str::<DeriveInput>(&input.to_string()[..])
     .expect("syntax error");
-  /* let input = DeriveInput {
-    attrs: vec![],
-    vis: syn::Visibility::Public(syn::VisPublic {
-      pub_token: syn::token::Pub { ..Default::default() },
-    }),
-    ident: syn::Ident::new("foo", proc_macro2::Span::call_site()),
-    data: syn::Data::Struct(syn::DataStruct {
-      fields: syn::Fields::Unit,
-      semi_token: None,
-      struct_token: syn::token::Struct { ..Default::default() },
-    }),
-    generics: syn::Generics { ..Default::default() },
-  }; */
   let result = derive_marker_trait::<Pod>(input);
-  println!("result:\n {}", result.to_string());
   assert!(result
     .to_string()
-    .contains("unsafe impl bytemuck :: Pod for Foo { }"));
+    .contains("unsafe impl :: bytemuck :: Pod for Foo { }"));
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -190,7 +190,12 @@ fn test_derive_output() {
   let input = syn::parse_str::<DeriveInput>(&input.to_string()[..])
     .expect("syntax error");
   let result = derive_marker_trait::<Pod>(input);
-  assert!(result
-    .to_string()
+
+  #[cfg(not(feature = "proc-macro-crate"))]
+  assert!(dbg!(result.to_string())
     .contains("unsafe impl bytemuck :: Pod for Foo { }"));
+
+  #[cfg(feature = "proc-macro-crate")]
+  assert!(dbg!(result.to_string())
+    .contains("unsafe impl :: bytemuck :: Pod for Foo { }"));
 }

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -332,7 +332,8 @@ fn parse_int_expr(expr: &Expr) -> Result<i64, &'static str> {
 
 #[cfg(not(feature = "proc-macro-crate"))]
 fn get_bytemuck_crate_name() -> TokenStream {
-    quote_spanned!(Span::mixed_site() => bytemuck)
+  use proc_macro2::Span;
+  quote_spanned!(Span::mixed_site() => bytemuck)
 }
 
 #[cfg(feature = "proc-macro-crate")]

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -27,11 +27,6 @@ pub struct Pod;
 impl Derivable for Pod {
   fn ident() -> TokenStream {
     let bytemuck_name = get_bytemuck_crate_name();
-    /* println!(
-      "old: {}\n new: {}",
-      quote!(::bytemuck::Pod),
-      quote!(#bytemuck_name::Pod)
-    ); */
     quote!(#bytemuck_name::Pod)
   }
 
@@ -335,6 +330,12 @@ fn parse_int_expr(expr: &Expr) -> Result<i64, &'static str> {
   }
 }
 
+#[cfg(not(feature = "proc-macro-crate"))]
+fn get_bytemuck_crate_name() -> TokenStream {
+    quote_spanned!(Span::mixed_site() => bytemuck)
+}
+
+#[cfg(feature = "proc-macro-crate")]
 fn get_bytemuck_crate_name() -> TokenStream {
   use proc_macro2::Span;
   use proc_macro_crate::{crate_name, FoundCrate};
@@ -354,7 +355,7 @@ fn get_bytemuck_crate_name() -> TokenStream {
     },
     // if not found
     Err(_) => {
-      quote_spanned!(Span::call_site() => self::bytemuck)
+      quote_spanned!(Span::mixed_site() => bytemuck)
     }
   }
 }


### PR DESCRIPTION
## The scenario:
I want to pull all my dependencies through a `deps` crate in my workspace and dynamic link to this `deps` crate to speed up compilation allowing one fast iteration times.

Look at the strategy deployed by [bevy](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dylib) for an example.

## The challenge:
Proc macro's stop working as they expect to find some of the crates they depend on to be imported in the current crate.

The `bytemuck_derive` crate works with types from `bytemuck`  using snippets as the one given below...
```rust
    quote!(::bytemuck::Pod)
```
...which fails to find the `bytemuck` crate as it's located in `crate::deps::bytemuck`.

Similar issues elsewhere: [serde](https://github.com/serde-rs/serde/issues/1465), [yew](https://github.com/yewstack/yew/issues/1454)

## The solution:

If unable to find `bytemuck` crate in the manifest of the crate using the macro (detection using [proc-macro-crate](http://lib.rs/proc-macro-crate)), use `self::bytemuck` qualifier. Anyone who intends to use re-exporting can then import `bytemuck::self` locally. 

```rust
use deps::bytemuck{self, Zeroable, Pod};

#[repr(C)]
#[derive(Clone, Copy, Zeroable, Pod)]
struct Vertex{
    pos: [u32; 4],
}
```

We avoid breaking changes by using the old `::bytemuck` qualifier if `bytemuck` is found in the manifest.

Courtesy of `proc-macro-crate`, we're also able to handle if `bytemuck` is found in the manifest but under a different name. 

Includes:
- adds `bytemuck_derive` into a workspace rooted in `bytemuck`