### PR TITLE
[Feature] extend `TransparentWrapper` conversion functions

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -12,5 +12,5 @@ use_small_heuristics = "Max"
 
 # Unstable
 format_code_in_doc_comments = true
-merge_imports = true
+imports_granularity = "Crate"
 wrap_comments = true

--- a/src/contiguous.rs
+++ b/src/contiguous.rs
@@ -85,8 +85,8 @@ pub unsafe trait Contiguous: Copy + 'static {
   /// `#[repr(Int)]` or `#[repr(C)]` attribute, (if it does not, it is
   /// *unsound* to implement `Contiguous`!).
   ///
-  /// - For `#[repr(Int)]`, use the listed `Int`. e.g. `#[repr(u8)]` should
-  ///   use `type Int = u8`.
+  /// - For `#[repr(Int)]`, use the listed `Int`. e.g. `#[repr(u8)]` should use
+  ///   `type Int = u8`.
   ///
   /// - For `#[repr(C)]`, use whichever type the C compiler will use to
   ///   represent the given enum. This is usually `c_int` (from `std::os::raw`

--- a/src/offset_of.rs
+++ b/src/offset_of.rs
@@ -25,7 +25,9 @@
 /// # use bytemuck::offset_of;
 /// // enums can't derive default, and for this example we don't pick one
 /// enum MyExampleEnum {
-///   A, B, C,
+///   A,
+///   B,
+///   C,
 /// }
 ///
 /// // so now our struct here doesn't have Default
@@ -65,11 +67,11 @@
 /// [rust-lang/rust#27060]: https://github.com/rust-lang/rust/issues/27060
 ///
 /// <p style="background:rgba(255,181,77,0.16);padding:0.75em;">
-/// <strong>Warning:</strong> This is only true for versions of bytemuck > 1.4.0.
-/// Previous versions of
+/// <strong>Warning:</strong> This is only true for versions of bytemuck >
+/// 1.4.0. Previous versions of
 /// <code style="background:rgba(41,24,0,0.1);">bytemuck::offset_of!</code>
-/// will only emit a warning when used on the field of a packed struct in safe code,
-/// which can lead to unsoundness.
+/// will only emit a warning when used on the field of a packed struct in safe
+/// code, which can lead to unsoundness.
 /// </p>
 ///
 /// For example, the following will fail to compile:
@@ -91,7 +93,8 @@
 /// ```compile_fail
 /// # #[repr(C, packed)] #[derive(Default)] struct Example { field: u32 }
 /// // Still doesn't compile:
-/// #[allow(safe_packed_borrows)] {
+/// #[allow(safe_packed_borrows)]
+/// {
 ///   let _offset = bytemuck::offset_of!(Example, field);
 /// }
 /// ```

--- a/src/transparent.rs
+++ b/src/transparent.rs
@@ -91,10 +91,10 @@ pub unsafe trait TransparentWrapper<Wrapped: ?Sized> {
   fn wrap_ref(s: &Wrapped) -> &Self {
     unsafe {
       assert!(size_of::<*const Wrapped>() == size_of::<*const Self>());
-      // Using a pointer cast doesn't work here because rustc can't tell that the
-      // vtables match (if we lifted the ?Sized restriction, this would go away),
-      // and transmute doesn't work for the usual reasons it doesn't work inside
-      // generic functions.
+      // Using a pointer cast doesn't work here because rustc can't tell that
+      // the vtables match (if we lifted the ?Sized restriction, this
+      // would go away), and transmute doesn't work for the usual reasons
+      // it doesn't work inside generic functions.
       //
       // SAFETY: The unsafe contract requires that these have identical
       // representations. Using this transmute_copy instead of transmute here is
@@ -110,16 +110,17 @@ pub unsafe trait TransparentWrapper<Wrapped: ?Sized> {
   /// wrapper.
   ///
   /// This is a trait method so that you can write `MyType::wrap_mut(...)` in
-  /// your code. It is part of the safety contract for this trait that if you implement
-  /// `TransparentWrapper<_>` for your type you **must not** override this method.
+  /// your code. It is part of the safety contract for this trait that if you
+  /// implement `TransparentWrapper<_>` for your type you **must not**
+  /// override this method.
   #[inline]
   fn wrap_mut(s: &mut Wrapped) -> &mut Self {
     unsafe {
       assert!(size_of::<*mut Wrapped>() == size_of::<*mut Self>());
-      // Using a pointer cast doesn't work here because rustc can't tell that the
-      // vtables match (if we lifted the ?Sized restriction, this would go away),
-      // and transmute doesn't work for the usual reasons it doesn't work inside
-      // generic functions.
+      // Using a pointer cast doesn't work here because rustc can't tell that
+      // the vtables match (if we lifted the ?Sized restriction, this
+      // would go away), and transmute doesn't work for the usual reasons
+      // it doesn't work inside generic functions.
       //
       // SAFETY: The unsafe contract requires that these have identical
       // representations. Using this transmute_copy instead of transmute here is

--- a/src/transparent.rs
+++ b/src/transparent.rs
@@ -1,9 +1,9 @@
 use super::*;
 
-/// A trait which indicates that a type is a `repr(transparent)` wrapper around
-/// the `Inner` value.
+/// A trait which indicates that a type is a `#[repr(transparent)]` wrapper
+/// around the `Inner` value.
 ///
-/// This allows safely transmuting between the `Inner` type and the
+/// This allows safely copy transmuting between the `Inner` type and the
 /// `TransparentWrapper` type.  
 /// Functions like `wrap_{}` convert from the inner
 /// type to the wrapper type and `unwrap_{}` functions do the inverse conversion

--- a/src/transparent.rs
+++ b/src/transparent.rs
@@ -168,18 +168,18 @@ pub unsafe trait TransparentWrapper<Inner: ?Sized> {
 
   /// Convert the wrapper type into the inner type.
   #[inline]
-  fn unwrap(self) -> Inner
+  fn unwrap(s: Self) -> Inner
   where
     Self: Sized,
     Inner: Sized,
   {
-    unsafe { transmute_copy(&self) }
+    unsafe { transmute_copy(&s) }
   }
 
   /// Convert a reference to the wrapper type into a reference to the inner
   /// type.
   #[inline]
-  fn unwrap_ref(&self) -> &Inner {
+  fn unwrap_ref(s: &Self) -> &Inner {
     unsafe {
       assert!(size_of::<*const Inner>() == size_of::<*const Self>());
       // A pointer cast does't work here because rustc can't tell that
@@ -188,7 +188,7 @@ pub unsafe trait TransparentWrapper<Inner: ?Sized> {
       //
       // SAFETY: The unsafe contract requires that these two have
       // identical representations.
-      let wrapper_ptr = self as *const Self;
+      let wrapper_ptr = s as *const Self;
       let inner_ptr: *const Inner = transmute_copy(&wrapper_ptr);
       &*inner_ptr
     }
@@ -197,7 +197,7 @@ pub unsafe trait TransparentWrapper<Inner: ?Sized> {
   /// Convert a mutable reference to the wrapper type into a mutable reference
   /// to the inner type.
   #[inline]
-  fn unwrap_mut(&mut self) -> &mut Inner {
+  fn unwrap_mut(s: &mut Self) -> &mut Inner {
     unsafe {
       assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
       // A pointer cast does't work here because rustc can't tell that
@@ -206,7 +206,7 @@ pub unsafe trait TransparentWrapper<Inner: ?Sized> {
       //
       // SAFETY: The unsafe contract requires that these two have
       // identical representations.
-      let wrapper_ptr = self as *mut Self;
+      let wrapper_ptr = s as *mut Self;
       let inner_ptr: *mut Inner = transmute_copy(&wrapper_ptr);
       &mut *inner_ptr
     }

--- a/tests/cast_slice_tests.rs
+++ b/tests/cast_slice_tests.rs
@@ -25,7 +25,8 @@ fn test_try_cast_slice() {
     Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
   );
 
-  // by taking one byte off the end, we're aligned but would have slop bytes for u32
+  // by taking one byte off the end, we're aligned but would have slop bytes for
+  // u32
   let the_bytes_len_minus1 = the_bytes.len() - 1;
   let slop_bytes = &the_bytes[..the_bytes_len_minus1];
   assert_eq!(
@@ -62,7 +63,8 @@ fn test_try_cast_slice_mut() {
     Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
   );
 
-  // by taking one byte off the end, we're aligned but would have slop bytes for u32
+  // by taking one byte off the end, we're aligned but would have slop bytes for
+  // u32
   let the_bytes_len_minus1 = the_bytes.len() - 1;
   let slop_bytes = &mut the_bytes[..the_bytes_len_minus1];
   assert_eq!(
@@ -92,7 +94,10 @@ fn test_types() {
 #[test]
 fn test_bytes_of() {
   assert_eq!(bytes_of(&0xaabbccdd_u32), &0xaabbccdd_u32.to_ne_bytes());
-  assert_eq!(bytes_of_mut(&mut 0xaabbccdd_u32), &mut 0xaabbccdd_u32.to_ne_bytes());
+  assert_eq!(
+    bytes_of_mut(&mut 0xaabbccdd_u32),
+    &mut 0xaabbccdd_u32.to_ne_bytes()
+  );
   let mut a = 0xaabbccdd_u32;
   let a_addr = &a as *const _ as usize;
   // ensure addresses match.
@@ -105,9 +110,18 @@ fn test_try_from_bytes() {
   let u32s = [0xaabbccdd, 0x11223344_u32];
   let bytes = bytemuck::cast_slice::<u32, u8>(&u32s);
   assert_eq!(try_from_bytes::<u32>(&bytes[..4]), Ok(&u32s[0]));
-  assert_eq!(try_from_bytes::<u32>(&bytes[..5]), Err(PodCastError::SizeMismatch));
-  assert_eq!(try_from_bytes::<u32>(&bytes[..3]), Err(PodCastError::SizeMismatch));
-  assert_eq!(try_from_bytes::<u32>(&bytes[1..5]), Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned));
+  assert_eq!(
+    try_from_bytes::<u32>(&bytes[..5]),
+    Err(PodCastError::SizeMismatch)
+  );
+  assert_eq!(
+    try_from_bytes::<u32>(&bytes[..3]),
+    Err(PodCastError::SizeMismatch)
+  );
+  assert_eq!(
+    try_from_bytes::<u32>(&bytes[1..5]),
+    Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
+  );
 }
 
 #[test]
@@ -117,9 +131,18 @@ fn test_try_from_bytes_mut() {
   let bytes = bytemuck::cast_slice_mut::<u32, u8>(&mut u32s);
   assert_eq!(try_from_bytes_mut::<u32>(&mut bytes[..4]), Ok(&mut abcd));
   assert_eq!(try_from_bytes_mut::<u32>(&mut bytes[..4]), Ok(&mut abcd));
-  assert_eq!(try_from_bytes_mut::<u32>(&mut bytes[..5]), Err(PodCastError::SizeMismatch));
-  assert_eq!(try_from_bytes_mut::<u32>(&mut bytes[..3]), Err(PodCastError::SizeMismatch));
-  assert_eq!(try_from_bytes::<u32>(&mut bytes[1..5]), Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned));
+  assert_eq!(
+    try_from_bytes_mut::<u32>(&mut bytes[..5]),
+    Err(PodCastError::SizeMismatch)
+  );
+  assert_eq!(
+    try_from_bytes_mut::<u32>(&mut bytes[..3]),
+    Err(PodCastError::SizeMismatch)
+  );
+  assert_eq!(
+    try_from_bytes::<u32>(&mut bytes[1..5]),
+    Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
+  );
 }
 
 #[test]
@@ -136,7 +159,10 @@ fn test_from_bytes_mut() {
   let a_addr = &a as *const _ as usize;
   let aligned_bytes = bytemuck::bytes_of_mut(&mut a);
   assert_eq!(*from_bytes_mut::<u32>(aligned_bytes), 0xaabbccdd_u32);
-  assert_eq!(from_bytes_mut::<u32>(aligned_bytes) as *const u32 as usize, a_addr);
+  assert_eq!(
+    from_bytes_mut::<u32>(aligned_bytes) as *const u32 as usize,
+    a_addr
+  );
 }
 
 // like #[should_panic], but can be a part of another test, instead of requiring
@@ -144,7 +170,10 @@ fn test_from_bytes_mut() {
 macro_rules! should_panic {
   ($ex:expr) => {
     assert!(
-      std::panic::catch_unwind(|| { let _ = $ex; }).is_err(),
+      std::panic::catch_unwind(|| {
+        let _ = $ex;
+      })
+      .is_err(),
       concat!("should have panicked: `", stringify!($ex), "`")
     );
   };

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "derive")]
 #![allow(dead_code)]
 
-use bytemuck::{Zeroable, Pod, TransparentWrapper};
+use bytemuck::{Pod, TransparentWrapper, Zeroable};
 
 #[derive(Copy, Clone, Pod, Zeroable)]
 #[repr(C)]
@@ -21,5 +21,5 @@ struct TransparentSingle {
 #[transparent(u16)]
 struct TransparentWithZeroSized {
   a: u16,
-  b: ()
+  b: (),
 }

--- a/tests/transparent.rs
+++ b/tests/transparent.rs
@@ -1,0 +1,64 @@
+// Currently this test doesn't actually check the output of the functions.
+// It's only here for miri to check for any potential undefined behaviour.
+// TODO: check function results
+
+#[test]
+fn test_transparent_wrapper() {
+  // An external type defined in a different crate.
+  #[derive(Copy, Clone, Default)]
+  struct Foreign(u8);
+
+  use bytemuck::TransparentWrapper;
+
+  #[derive(Copy, Clone)]
+  #[repr(transparent)]
+  struct Wrapper(Foreign);
+
+  unsafe impl TransparentWrapper<Foreign> for Wrapper {}
+
+  // Traits can be implemented on crate-local wrapper.
+  unsafe impl bytemuck::Zeroable for Wrapper {}
+  unsafe impl bytemuck::Pod for Wrapper {}
+
+  let _: u8 = bytemuck::cast(Wrapper::wrap(Foreign::default()));
+  let _: Foreign = Wrapper::unwrap(bytemuck::cast(u8::default()));
+
+  let _: &u8 = bytemuck::cast_ref(Wrapper::wrap_ref(&Foreign::default()));
+  let _: &Foreign = Wrapper::unwrap_ref(bytemuck::cast_ref(&u8::default()));
+
+  let _: &mut u8 =
+    bytemuck::cast_mut(Wrapper::wrap_mut(&mut Foreign::default()));
+  let _: &mut Foreign =
+    Wrapper::unwrap_mut(bytemuck::cast_mut(&mut u8::default()));
+
+  let _: &[u8] =
+    bytemuck::cast_slice(Wrapper::wrap_slice(&[Foreign::default()]));
+  let _: &[Foreign] =
+    Wrapper::unwrap_slice(bytemuck::cast_slice(&[u8::default()]));
+
+  let _: &mut [u8] =
+    bytemuck::cast_slice_mut(Wrapper::wrap_slice_mut(
+      &mut [Foreign::default()],
+    ));
+  let _: &mut [Foreign] =
+    Wrapper::unwrap_slice_mut(bytemuck::cast_slice_mut(&mut [u8::default()]));
+
+  let _: &[u8] = bytemuck::bytes_of(Wrapper::wrap_ref(&Foreign::default()));
+  let _: &Foreign = Wrapper::unwrap_ref(bytemuck::from_bytes(&[u8::default()]));
+
+  let _: &mut [u8] =
+    bytemuck::bytes_of_mut(Wrapper::wrap_mut(&mut Foreign::default()));
+  let _: &mut Foreign =
+    Wrapper::unwrap_mut(bytemuck::from_bytes_mut(&mut [u8::default()]));
+
+  // not sure if this is the right usage
+  let _ =
+    bytemuck::pod_align_to::<_, u8>(Wrapper::wrap_slice(&[Foreign::default()]));
+  // counterpart?
+
+  // not sure if this is the right usage
+  let _ = bytemuck::pod_align_to_mut::<_, u8>(Wrapper::wrap_slice_mut(&mut [
+    Foreign::default(),
+  ]));
+  // counterpart?
+}


### PR DESCRIPTION
This PR extends the `TransparentWrapper` trait by adding new conversion functions.
Namely:

These three missing `wrap_{}` functions.
- `TransparentWrapper::wrap(s: Inner) -> Self`
- `TransparentWrapper::wrap_slice(s: &[Inner]) -> &[Self]`
- `TransparentWrapper::wrap_slice_mut(s: &mut [Inner]) -> &mut [Self]`

These five `unwrap_{}` functions, which are the counterparts of the `wrap_{}` functions. They just invert the conversion.
- `TransparentWrapper::unwrap(self) -> Inner`
- `TransparentWrapper::unwrap_ref(&self) -> &Inner`
- `TransparentWrapper::unwrap_mut(&mut self) -> &mut Inner`
- `TransparentWrapper::unwrap_slice(s: &[Self]) -> &[Inner]`
- `TransparentWrapper::unwrap_slice_mut(s: &mut [Self]) -> &mut [Inner]`


This is useful for implementing `Zeroable` and `Pod` on types from extern crates in order to use `bytemuck::{}` functions like `bytemuck::cast_slice` using the new-ype pattern and `TransparentWrapper`.

The goal of this PR is to support all `bytemuck::{}` functions.

This is possible with this PR:
```rust
  // An external type defined in a different crate.
  #[derive(Copy, Clone, Default)]
  struct Foreign(u8);

  use bytemuck::TransparentWrapper;

  #[derive(Copy, Clone)]
  #[repr(transparent)]
  struct Wrapper(Foreign);

  unsafe impl TransparentWrapper<Foreign> for Wrapper {}

  // Traits can be implemented on crate-local wrapper.
  unsafe impl bytemuck::Zeroable for Wrapper {}
  unsafe impl bytemuck::Pod for Wrapper {}

  let _: u8 = bytemuck::cast(Wrapper::wrap(Foreign::default()));
  let _: Foreign = Wrapper::unwrap(bytemuck::cast(u8::default()));

  let _: &u8 = bytemuck::cast_ref(Wrapper::wrap_ref(&Foreign::default()));
  let _: &Foreign = Wrapper::unwrap_ref(bytemuck::cast_ref(&u8::default()));

  let _: &mut u8 = bytemuck::cast_mut(Wrapper::wrap_mut(&mut Foreign::default()));
  let _: &mut Foreign = Wrapper::unwrap_mut(bytemuck::cast_mut(&mut u8::default()));

  let _: &[u8] = bytemuck::cast_slice(Wrapper::wrap_slice(&[Foreign::default()]));
  let _: &[Foreign] = Wrapper::unwrap_slice(bytemuck::cast_slice(&[u8::default()]));

  let _: &mut [u8] = bytemuck::cast_slice_mut(Wrapper::wrap_slice_mut(&mut [Foreign::default()]));
  let _: &mut [Foreign] = Wrapper::unwrap_slice_mut(bytemuck::cast_slice_mut(&mut [u8::default()]));

  let _: &[u8] = bytemuck::bytes_of(Wrapper::wrap_ref(&Foreign::default()));
  let _: &Foreign = Wrapper::unwrap_ref(bytemuck::from_bytes(&[u8::default()]));

  let _: &mut [u8] = bytemuck::bytes_of_mut(Wrapper::wrap_mut(&mut Foreign::default()));
  let _: &mut Foreign = Wrapper::unwrap_mut(bytemuck::from_bytes_mut(&mut [u8::default()]));

  // not sure if this is the right usage
  let _ = bytemuck::pod_align_to::<_, u8>(Wrapper::wrap_slice(&[Foreign::default()]));
  // counterpart?

  // not sure if this is the right usage
  let _ = bytemuck::pod_align_to_mut::<_, u8>(Wrapper::wrap_slice_mut(&mut [Foreign::default()]));
  // counterpart?
```

This PR also includes a test, which uses the exact example code from above. This is for MIRI to check for any potential UB.
As you can see, there currently isn't any checking done on the output of the functions. This is something left todo.

Can somebody please check the soundness of the implementation, because I have very little expertise with unsafe code.

I've written up some docs on how this trait can be used in combination with the newtype pattern to use the bytemuck functions on foreign types from external crates.

I also adjusted `rustfmt.toml` in the first commit, because of the deprecation of `merge_imports = true`. It is being replaced by `imports_granularity = "Crate"`. Furthermore I ran `cargo +nightly fmt` to format the codebase. I hope these two changes are fine.

I'm open to suggestions!

This is my first PR ever 🥳 .