### PR TITLE
Implement Pod and Zeroable for arrays of any size

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn main() {
   };
 
   if minor >= 51 {
-    println!("cargo:rustc-cfg=const_generics_mvp");
+    println!("cargo:rustc-cfg=min_const_generics");
   }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,45 @@
+use std::{
+  env,
+  process::Command,
+  str::{self, FromStr},
+};
+
+fn main() {
+  let minor = match rustc_minor_version() {
+    Some(minor) => minor,
+    None => return,
+  };
+
+  if minor >= 51 {
+    println!("cargo:rustc-cfg=const_generics_mvp");
+  }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+  let rustc = match env::var_os("RUSTC") {
+    Some(rustc) => rustc,
+    None => return None,
+  };
+
+  let output = match Command::new(rustc).arg("--version").output() {
+    Ok(output) => output,
+    Err(_) => return None,
+  };
+
+  let version = match str::from_utf8(&output.stdout) {
+    Ok(version) => version,
+    Err(_) => return None,
+  };
+
+  let mut pieces = version.split('.');
+  if pieces.next() != Some("rustc 1") {
+    return None;
+  }
+
+  let next = match pieces.next() {
+    Some(next) => next,
+    None => return None,
+  };
+
+  u32::from_str(next).ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ use core::{marker::*, mem::*, num::*, ptr::*};
 #[doc(hidden)]
 pub use ::core as __core;
 
+#[cfg(not(generic_const))]
 macro_rules! impl_unsafe_marker_for_array {
   ( $marker:ident , $( $n:expr ),* ) => {
     $(unsafe impl<T> $marker for [T; $n] where T: $marker {})*

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -66,6 +66,10 @@ unsafe impl<T: Pod> Pod for ManuallyDrop<T> {}
 
 // Note(Lokathor): MaybeUninit can NEVER be Pod.
 
+#[cfg(const_generics_mvp)]
+unsafe impl<T, const N: usize> Pod for [T; N] where T: Pod {}
+
+#[cfg(not(const_generics_mvp))]
 impl_unsafe_marker_for_array!(
   Pod, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
   20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256,

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -66,10 +66,10 @@ unsafe impl<T: Pod> Pod for ManuallyDrop<T> {}
 
 // Note(Lokathor): MaybeUninit can NEVER be Pod.
 
-#[cfg(const_generics_mvp)]
+#[cfg(min_const_generics)]
 unsafe impl<T, const N: usize> Pod for [T; N] where T: Pod {}
 
-#[cfg(not(const_generics_mvp))]
+#[cfg(not(min_const_generics))]
 impl_unsafe_marker_for_array!(
   Pod, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
   20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256,

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -109,6 +109,10 @@ unsafe impl<
 {
 }
 
+#[cfg(const_generics_mvp)]
+unsafe impl<T, const N: usize> Zeroable for [T; N] where T: Zeroable {}
+
+#[cfg(not(const_generics_mvp))]
 impl_unsafe_marker_for_array!(
   Zeroable, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
   19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256,

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -109,10 +109,10 @@ unsafe impl<
 {
 }
 
-#[cfg(const_generics_mvp)]
+#[cfg(min_const_generics)]
 unsafe impl<T, const N: usize> Zeroable for [T; N] where T: Zeroable {}
 
-#[cfg(not(const_generics_mvp))]
+#[cfg(not(min_const_generics))]
 impl_unsafe_marker_for_array!(
   Zeroable, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
   19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256,


### PR DESCRIPTION
Starting with Rust 1.51 it is possible to use const generics in limited way.
But it's sufficient to implement traits for arrays of all sizes.