### PR TITLE
Spir-v: just gate the Display impl instead

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,12 +231,9 @@ pub enum PodCastError {
   /// exact.
   AlignmentMismatch,
 }
+#[cfg(not(target_arch = "spirv"))]
 impl core::fmt::Display for PodCastError {
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    // Currently, this is unlikely to work for the spirv targets
-    #[cfg(target_arch = "spirv")]
-    write!(f, "PodCastError");
-    #[cfg(not(target_arch = "spirv"))]
     write!(f, "{:?}", self)
   }
 }


### PR DESCRIPTION
The old version didn't compile (because of the extra semicolon). 

It is extremely unlikely that anyone would ever want to use this impl on gpu, at least whilst the compiler is in its current state - if the impls did start working, they could just use the `Debug` impl.

This is not a breaking change, since all prior versions didn't compile on spir-v anyway. 

As a small note, there is no expectation for you to proactively support the spir-v target; beyond checking PRs which fixup any breakage - bytemuck stopping compiling would be the least breaking change in the entire rust-gpu ecosystem.