### PR TITLE
Support WASM SIMD's `v128` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ extern_crate_alloc = []
 extern_crate_std = ["extern_crate_alloc"]
 zeroable_maybe_uninit = []
 min_const_generics = []
+wasm_simd = [] # Until >= 1.54.0 is MSRV this is an off-by-default feature.
 
 # Do not use if you can avoid it, because this is unsound.
 unsound_ptr_pod_impl = []
@@ -35,6 +36,7 @@ features = [
   "extern_crate_std",
   "zeroable_maybe_uninit",
   "min_const_generics",
+  "wasm_simd",
 ]
 
 [package.metadata.playground]
@@ -45,4 +47,5 @@ features = [
   "extern_crate_std",
   "zeroable_maybe_uninit",
   "min_const_generics",
+  "wasm_simd",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@
 //!   methods related to `Box` and `Vec`. Note that the `docs.rs` documentation
 //!   is always built with `extern_crate_alloc` cargo feature enabled.
 
+#[cfg(all(target_arch = "wasm32", feature = "wasm_simd"))]
+use core::arch::wasm32;
 #[cfg(target_arch = "x86")]
 use core::arch::x86;
 #[cfg(target_arch = "x86_64")]
@@ -115,7 +117,7 @@ fn something_went_wrong(_src: &str, _err: PodCastError) -> ! {
   panic!("{src}>{err:?}", src = _src, err = _err);
   // Note: On the spirv targets from [rust-gpu](https://github.com/EmbarkStudios/rust-gpu)
   // panic formatting cannot be used. We we just give a generic error message
-  // The chance that the panicing version of these functions will ever get called
+  // The chance that the panicking version of these functions will ever get called
   // on spir-v targets with invalid inputs is small, but giving a simple error
   // message is better than no error message at all.
   #[cfg(target_arch = "spirv")]

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -80,6 +80,9 @@ impl_unsafe_marker_for_array!(
   512, 1024, 2048, 4096
 );
 
+#[cfg(all(target_arch = "wasm32", feature = "wasm_simd"))]
+unsafe impl Pod for wasm32::v128 {}
+
 #[cfg(target_arch = "x86")]
 unsafe impl Pod for x86::__m128i {}
 #[cfg(target_arch = "x86")]

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -119,6 +119,9 @@ impl_unsafe_marker_for_array!(
   512, 1024, 2048, 4096
 );
 
+#[cfg(all(target_arch = "wasm32", feature = "wasm_simd"))]
+unsafe impl Zeroable for wasm32::v128 {}
+
 #[cfg(target_arch = "x86")]
 unsafe impl Zeroable for x86::__m128i {}
 #[cfg(target_arch = "x86")]


### PR DESCRIPTION
Due to the MSRV it is behind a feature gate.