### PR TITLE
minor doc patch to help users adjust their Cargo.toml for usage of the allocation module.

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -5,7 +5,7 @@
 //! * You must enable the `extern_crate_alloc` feature of `bytemuck` or you will
 //!   not be able to use this module! This is generally done by adding the
 //!   feature to the dependency in Cargo.toml like so: 
-//!   `bytemuck = { version = "*", features = ["extern_crate_alloc"]}`
+//!   `bytemuck = { version = "VERSION_YOU_ARE_USING", features = ["extern_crate_alloc"]}`
 
 
 use super::*;


### PR DESCRIPTION
I'm expecting to update https://docs.rs/bytemuck/1.7.2/bytemuck/allocation/index.html with the following:

> This is generally done by adding the feature to the dependency in Cargo.toml like so: 
>`bytemuck = { version = "VERSION_YOU_ARE_USING", features = ["extern_crate_alloc"]}`
