### PR TITLE
Make `Pod` and `Zeroable` derives work for some generic structs and improve docs

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,7 +15,7 @@ name = "bytemuck_derive"
 proc-macro = true
 
 [dependencies]
-syn = "1"
+syn = { version = "1", features = ["extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -13,14 +13,13 @@ use crate::traits::{Contiguous, Derivable, Pod, TransparentWrapper, Zeroable};
 /// Derive the `Pod` trait for a struct
 ///
 /// The macro ensures that the struct follows all the the safety requirements
-/// for the `Pod` trait.
+/// for the `Pod` trait which implies that the types of all struct fields have
+/// to implement `Pod`.
 ///
-/// The following constraints need to be satisfied for the macro to succeed
-///
-/// - All fields in the struct must implement `Pod`
-/// - The struct must be `#[repr(C)]` or `#[repr(transparent)]`
-/// - The struct must not contain any padding bytes
-/// - The struct contains no generic parameters
+/// Generally, a struct with generic types is not allowed by this macro as the
+/// struct's padding cannot be checked then. However, there is one special
+/// case: if all struct fields have the same generic type, the macro suceeds
+/// and the generated `impl` will have a `T: Pod` bound.
 ///
 /// ## Example
 ///

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -20,6 +20,9 @@ pub trait Derivable {
   fn trait_impl(_input: &DeriveInput) -> Result<TokenStream, &'static str> {
     Ok(quote!())
   }
+  fn extra_where_bounds(_input: &DeriveInput) -> Result<TokenStream, &'static str> {
+    Ok(quote!())
+  }
 }
 
 pub struct Pod;
@@ -63,8 +66,11 @@ impl Derivable for Zeroable {
     quote!(::bytemuck::Zeroable)
   }
 
-  fn struct_asserts(input: &DeriveInput) -> Result<TokenStream, &'static str> {
-    generate_fields_are_trait(input, Self::ident())
+  fn extra_where_bounds(input: &DeriveInput) -> Result<TokenStream, &'static str> {
+    let fields = get_struct_fields(input)?;
+    let field_types = get_field_types(&fields);
+    let trait_ = Self::ident();
+    Ok(quote! { #( #field_types: #trait_ , )* })
   }
 }
 

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -54,3 +54,12 @@ struct Generic<T> {
   x: T,
   y: T,
 }
+
+// See https://github.com/Lokathor/bytemuck/issues/75
+#[derive(Clone, Copy, Zeroable, Pod)]
+#[repr(C)]
+struct GenericAllSameType<T> {
+  a: T,
+  b: T,
+  c: T,
+}

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -48,3 +48,9 @@ enum ContiguousWithImplicitValues {
   D,
   E,
 }
+
+#[derive(Zeroable)]
+struct Generic<T> {
+  x: T,
+  y: T,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,15 +23,30 @@
 //! ## Using Your Own Types
 //!
 //! All the functions here are guarded by the [`Pod`] trait, which is a
-//! sub-trait of the [`Zeroable`] trait.
+//! sub-trait of the [`Zeroable`] trait. To implement these traits for your own
+//! types, you have two options: using the provided derive macros or
+//! implementing them manually.
 //!
-//! If you're very sure that your type is eligible, you can implement those
-//! traits for your type and then they'll have full casting support. However,
-//! these traits are `unsafe`, and you should carefully read the requirements
-//! before adding the them to your own types.
+//! The derive macros are usually the preferred option as they will cause a
+//! compiler error if they cannot verify that your type is allowed to implement
+//! a specific trait. Thus, they are safe to use and you can avoid having
+//! `unsafe` in your code. To use derives, enable the `derive` crate feature!
+//!
+//! However, the derive macros only work for a subset of types that could
+//! implement the traits in this crate. For the remaining cases (or if you want
+//! to avoid the extra dependencies), you can implement these traits manually.
+//! But since these are `unsafe` traits, please take great care to verify your
+//! type actually satisfies the requirements of each trait! Failing to do so
+//! will very likely result in undefined behavior.
 //!
 //! ## Features
 //!
+//! * `derive`: enables derive macros.
+//! * `zeroable_maybe_uninit`: Implements `Zeroable` for `std::mem::MaybeUninit`
+//!   (Requires Rust 1.36).
+//! * `min_const_generics`: if enabled, arrays of any size implement `Pod` and
+//!   `Zeroable`. If disabled, only some sizes (0–32 and some powers of two)
+//!   implement the traits. (Requires Rust 1.51)
 //! * This crate is core only by default, but if you're using Rust 1.36 or later
 //!   you can enable the `extern_crate_alloc` cargo feature for some additional
 //!   methods related to `Box` and `Vec`. Note that the `docs.rs` documentation


### PR DESCRIPTION
Fixes #75 
Fixes #51 

- `derive(Zeroable)` now works for structs with generic fields. The `impl` is bounded with `T: Zeroable` for each struct field `T`.
- `derive(Pod)` now works for structs where all fields have the same generic type. Again, the `impl` is bounded with `T: Pod` then.
- I improved some documentation and mentioned the derive feature in the crate-level docs.

**Note**: the code emitted by the derive macros is slightly different with this PR. This has the unfortunate consequence that some compiler errors (for when a struct's field does not implement `Pod`) are worse than before. However, this was due to a Rust issue which has been fixed and will be released on January 13 as 1.58. See #75 for more details. 