### PR TITLE
nightly_no_coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,12 @@ unsound_ptr_pod_impl = []
 
 # NOT SEMVER SUPPORTED! TEMPORARY ONLY!
 nightly_portable_simd = []
+nightly_no_coverage = ["bytemuck_derive/nightly_no_coverage"]
 
 [dependencies]
 # use the upper line for testing against bytemuck_derive changes, if any
-#bytemuck_derive = { version = "1.0.1-alpha.0", path = "derive", optional = true }
-bytemuck_derive = { version = "1", optional = true }
+bytemuck_derive = { version = "1.0.2-alpha.0", path = "derive", optional = true }
+#bytemuck_derive = { version = "1.0.2-alpha.0", optional = true }
 
 [package.metadata.docs.rs]
 # Note(Lokathor): Don't use all-feautures or it would use `unsound_ptr_pod_impl` too.

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -10,6 +10,10 @@ categories = ["encoding", "no-std"]
 edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
 
+[features]
+# NOT SEMVER SUPPORTED! TEMPORARY ONLY!
+nightly_no_coverage = [] # https://github.com/rust-lang/rust/issues/84605
+
 [lib]
 name = "bytemuck_derive"
 proc-macro = true


### PR DESCRIPTION
⚠️ I don't know if this should actually be merged as is. ⚠️

This relies on `#![feature(no_coverage)]` in the root of **each crate using** the derive macros, which is awkward, because it's quite possible only one crate opted into the feature.  Perhaps it'd be better to generate `#[cfg_attr(feature = "nightly_no_coverage", no_coverage)]` instead, and then have the crates that want `#[no_coverage]` define a feature on themselves?

rust-lang tracking issue: https://github.com/rust-lang/rust/issues/84605

## What is this?

Unit test coverage tools are nice, but the never-called anonymous functions that bytemuck uses to assert things are safe cause [grcov](https://github.com/mozilla/grcov) and other tools to scold us for not testing said functions:

![image](https://user-images.githubusercontent.com/75894/149442263-10756285-96e9-4cde-9f02-75e77a467308.png)

This changelist fixes that:

![image](https://user-images.githubusercontent.com/75894/149442300-76b2f6f7-5153-4fd7-894a-87ed75ae2c89.png)
