### PR TITLE
unsafe_unsound_unstable_remove_static_asserts_for_coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ nightly_portable_simd = []
 
 [dependencies]
 # use the upper line for testing against bytemuck_derive changes, if any
-#bytemuck_derive = { version = "1.0.1-alpha.0", path = "derive", optional = true }
-bytemuck_derive = { version = "1", optional = true }
+bytemuck_derive = { version = "1.0.2-alpha.0", path = "derive", optional = true }
+#bytemuck_derive = { version = "1.0.2-alpha.0", optional = true }
 
 [package.metadata.docs.rs]
 # Note(Lokathor): Don't use all-feautures or it would use `unsound_ptr_pod_impl` too.


### PR DESCRIPTION
More stable-friendly replacement for https://github.com/Lokathor/bytemuck/pull/88

Since this is a `--cfg` and not a feature, and it has a scary name, it should be quite difficult and unnecessary for libraries to accidentally relax soundness checks.  It'd also be reasonable to ignore this PR and let people temporarilly patch their bytemuck downstream instead per https://github.com/MaulingMonkey/thindx/commit/b6dd1844917a511797280bafb5d8c5406e6ab532 :
```toml
# Cargo.toml
[patch.crates-io]
bytemuck.git            = "https://github.com/MaulingMonkey/bytemuck"
bytemuck_derive.git     = "https://github.com/MaulingMonkey/bytemuck"
bytemuck.branch         = "pr-unsafe-unsound-unstable-remove-static-asserts-for-coverage"
bytemuck_derive.branch  = "pr-unsafe-unsound-unstable-remove-static-asserts-for-coverage"
```
