### PR TITLE
Support unions in derive macros

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -5,8 +5,8 @@ extern crate proc_macro;
 mod traits;
 
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use quote::{quote, quote_spanned};
+use syn::{parse_macro_input, DeriveInput, spanned::Spanned};
 
 use crate::traits::{
   AnyBitPattern, Contiguous, Derivable, CheckedBitPattern, NoPadding, Pod, TransparentWrapper, Zeroable,
@@ -223,8 +223,9 @@ pub fn derive_contiguous(
 
 /// Basic wrapper for error handling
 fn derive_marker_trait<Trait: Derivable>(input: DeriveInput) -> TokenStream {
+  let span = input.span();
   derive_marker_trait_inner::<Trait>(input).unwrap_or_else(|err| {
-    quote! {
+    quote_spanned! { span =>
       compile_error!(#err);
     }
   })

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use bytemuck::{
-  AnyBitPattern, Contiguous, CheckedBitPattern, NoPadding, Pod, TransparentWrapper, Zeroable,
+  Contiguous, CheckedBitPattern, NoPadding, Pod, TransparentWrapper, Zeroable, AnyBitPattern,
 };
 use std::marker::PhantomData;
 
@@ -55,6 +55,20 @@ enum ContiguousWithImplicitValues {
 #[repr(C)]
 struct NoPaddingTest {
   a: u16,
+  b: u16,
+}
+
+#[derive(Copy, Clone, NoPadding)]
+#[repr(C)]
+union UnionTestNoPadding {
+  a: NoPaddingTest,
+  b: Test,
+}
+
+#[derive(Copy, Clone, AnyBitPattern)]
+#[repr(C)]
+union UnionTestAnyBitPattern {
+  a: u8,
   b: u16,
 }
 

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -58,6 +58,13 @@ struct NoPaddingTest {
   b: u16,
 }
 
+#[derive(Copy, Clone, Pod, Zeroable)]
+#[repr(C)]
+union UnionTestPod {
+  a: Test,
+  b: u32,
+}
+
 #[derive(Copy, Clone, NoPadding)]
 #[repr(C)]
 union UnionTestNoPadding {

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -58,20 +58,6 @@ struct NoPaddingTest {
   b: u16,
 }
 
-#[derive(Copy, Clone, Pod, Zeroable)]
-#[repr(C)]
-union UnionTestPod {
-  a: Test,
-  b: u32,
-}
-
-#[derive(Copy, Clone, NoPadding)]
-#[repr(C)]
-union UnionTestNoPadding {
-  a: NoPaddingTest,
-  b: Test,
-}
-
 #[derive(Copy, Clone, AnyBitPattern)]
 #[repr(C)]
 union UnionTestAnyBitPattern {


### PR DESCRIPTION
This adds support for unions in the derive macros.

The logic goes:

- All unions are `AnyBitPattern` because actually accessing them is unsafe anyhow
- ~~Unions are `NoPadding` (and `Pod`, since they're always `AnyBitPattern`) if~~
    - ~~All their fields are `NoPadding`~~
    - ~~All their fields are the same size (therefore no padding added at the end of any variants)~~

