### PR TITLE
Bump `bytemuck_derive` dependency to required version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ nightly_portable_simd = []
 [dependencies]
 # use the upper line for testing against bytemuck_derive changes, if any
 #bytemuck_derive = { path = "./derive", optional = true }
-bytemuck_derive = { version = "1", optional = true }
+bytemuck_derive = { version = "1.1", optional = true }
 
 [package.metadata.docs.rs]
 # Note(Lokathor): Don't use all-feautures or it would use `unsound_ptr_pod_impl` too.


### PR DESCRIPTION
When the `"derive"` feature is enabled for `bytemuck` the new derive structs introduced in version 1.1.0 are required for compilation. The cargo dependency resolver needs to be informed of this requirement to avoid build failures like the one seen here: https://buildkite.com/solana-labs/solana/builds/69315#691a7be6-1fba-4937-811d-70b9ed620598