### PR TITLE
Make `AnyBitPattern` derive work for generic structs

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -246,7 +246,7 @@ fn derive_marker_trait_inner<Trait: Derivable>(
   let (trait_impl_extras, trait_impl) = Trait::trait_impl(&input)?;
 
   let implies_trait = if let Some(implies_trait) = Trait::implies_trait() {
-    quote!(unsafe impl #implies_trait for #name {})
+    quote!(unsafe impl #impl_generics #implies_trait for #name #ty_generics #where_clause {})
   } else {
     quote!()
   };

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -104,9 +104,9 @@ struct CheckedBitPatternStruct {
 
 #[derive(Debug, Copy, Clone, AnyBitPattern, PartialEq, Eq)]
 #[repr(C)]
-struct AnyBitPatternTest {
-  a: u16,
-  b: u16
+struct AnyBitPatternTest<A: AnyBitPattern, B: AnyBitPattern> {
+  a: A,
+  b: B,
 }
 
 #[test]
@@ -150,6 +150,6 @@ fn passes_cast_struct() {
 
 #[test]
 fn anybitpattern_implies_zeroable() {
-  let test = AnyBitPatternTest::zeroed();
-  assert_eq!(test, AnyBitPatternTest { a: 0, b: 0 });
+  let test = AnyBitPatternTest::<isize, usize>::zeroed();
+  assert_eq!(test, AnyBitPatternTest { a: 0isize, b: 0usize });
 }


### PR DESCRIPTION
(Note: despite the similar titles, this PR is not related to #83 at all. This PR is specific to the changes introduced in #91.)

When using `AnyBitPattern` derive, an automatic derive for `Zeroable` is created as well. However, the latter derive is missing generic parameters for the struct, which means you get errors like the following:

```
error[E0107]: missing generics for struct `AnyBitPatternTest`
   --> tests/basic.rs:107:8
    |
107 | struct AnyBitPatternTest<A: AnyBitPattern, B: AnyBitPattern> {
    |        ^^^^^^^^^^^^^^^^^ expected 2 generic arguments
    |
note: struct defined here, with 2 generic parameters: `A`, `B`
   --> tests/basic.rs:107:8
    |
107 | struct AnyBitPatternTest<A: AnyBitPattern, B: AnyBitPattern> {
    |        ^^^^^^^^^^^^^^^^^ -                 -
help: add missing generic arguments
    |
107 | struct AnyBitPatternTest<A, B><A: AnyBitPattern, B: AnyBitPattern> {
    |        ~~~~~~~~~~~~~~~~~~~~~~~
```

The help text is worse than useless, because the suggested fix makes things worse.