### PR TITLE
Use `-Zmiri-tag-raw-pointers in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,6 +64,8 @@ jobs:
   miri-test:
     name: Test with miri
     runs-on: ubuntu-latest
+    env:
+      MIRIFLAGS: -Zmiri-tag-raw-pointers
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:


### PR DESCRIPTION
Normal Miri does not provide sufficient safety guarantees. Using the flag `-Zmiri-tag-raw-pointers` also checks usage of pointers in a more strict way.

I hope this works like this, haven't done Github Actions in a while