### PR TITLE
feat: ZeroableInOption and PodInOption traits

### DIFF
--- a/src/pod.rs
+++ b/src/pod.rs
@@ -52,25 +52,33 @@ unsafe impl Pod for f32 {}
 unsafe impl Pod for f64 {}
 unsafe impl<T: Pod> Pod for Wrapping<T> {}
 
-unsafe impl Pod for Option<NonZeroI8> {}
-unsafe impl Pod for Option<NonZeroI16> {}
-unsafe impl Pod for Option<NonZeroI32> {}
-unsafe impl Pod for Option<NonZeroI64> {}
-unsafe impl Pod for Option<NonZeroI128> {}
-unsafe impl Pod for Option<NonZeroIsize> {}
-unsafe impl Pod for Option<NonZeroU8> {}
-unsafe impl Pod for Option<NonZeroU16> {}
-unsafe impl Pod for Option<NonZeroU32> {}
-unsafe impl Pod for Option<NonZeroU64> {}
-unsafe impl Pod for Option<NonZeroU128> {}
-unsafe impl Pod for Option<NonZeroUsize> {}
+/// Trait for types which are [Pod](Pod) when wrapped in [Option](core::option::Option).
+/// 
+/// ## Safety
+/// 
+/// * `Option<T>` must uphold the same invariants as [Pod](Pod).
+pub unsafe trait PodInOption: ZeroableInOption + Copy + 'static {}
+unsafe impl<T: PodInOption> Pod for Option<T> {}
+
+unsafe impl PodInOption for NonZeroI8 {}
+unsafe impl PodInOption for NonZeroI16 {}
+unsafe impl PodInOption for NonZeroI32 {}
+unsafe impl PodInOption for NonZeroI64 {}
+unsafe impl PodInOption for NonZeroI128 {}
+unsafe impl PodInOption for NonZeroIsize {}
+unsafe impl PodInOption for NonZeroU8 {}
+unsafe impl PodInOption for NonZeroU16 {}
+unsafe impl PodInOption for NonZeroU32 {}
+unsafe impl PodInOption for NonZeroU64 {}
+unsafe impl PodInOption for NonZeroU128 {}
+unsafe impl PodInOption for NonZeroUsize {}
 
 #[cfg(feature = "unsound_ptr_pod_impl")]
 unsafe impl<T: 'static> Pod for *mut T {}
 #[cfg(feature = "unsound_ptr_pod_impl")]
 unsafe impl<T: 'static> Pod for *const T {}
 #[cfg(feature = "unsound_ptr_pod_impl")]
-unsafe impl<T: 'static> Pod for Option<NonNull<T>> {}
+unsafe impl<T: 'static> PodInOption for NonNull<T> {}
 
 unsafe impl<T: Pod> Pod for PhantomData<T> {}
 unsafe impl Pod for PhantomPinned {}

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -42,22 +42,30 @@ unsafe impl Zeroable for f32 {}
 unsafe impl Zeroable for f64 {}
 unsafe impl<T: Zeroable> Zeroable for Wrapping<T> {}
 
-unsafe impl Zeroable for Option<NonZeroI8> {}
-unsafe impl Zeroable for Option<NonZeroI16> {}
-unsafe impl Zeroable for Option<NonZeroI32> {}
-unsafe impl Zeroable for Option<NonZeroI64> {}
-unsafe impl Zeroable for Option<NonZeroI128> {}
-unsafe impl Zeroable for Option<NonZeroIsize> {}
-unsafe impl Zeroable for Option<NonZeroU8> {}
-unsafe impl Zeroable for Option<NonZeroU16> {}
-unsafe impl Zeroable for Option<NonZeroU32> {}
-unsafe impl Zeroable for Option<NonZeroU64> {}
-unsafe impl Zeroable for Option<NonZeroU128> {}
-unsafe impl Zeroable for Option<NonZeroUsize> {}
+/// Trait for types which are [Zeroable](Zeroable) when wrapped in [Option](core::option::Option).
+/// 
+/// ## Safety
+/// 
+/// * `Option<T>` must uphold the same invariants as [Zeroable](Zeroable).
+pub unsafe trait ZeroableInOption: Sized {}
+unsafe impl<T: ZeroableInOption> Zeroable for Option<T> {}
+
+unsafe impl ZeroableInOption for NonZeroI8 {} 
+unsafe impl ZeroableInOption for NonZeroI16 {}
+unsafe impl ZeroableInOption for NonZeroI32 {}
+unsafe impl ZeroableInOption for NonZeroI64 {}
+unsafe impl ZeroableInOption for NonZeroI128 {}
+unsafe impl ZeroableInOption for NonZeroIsize {}
+unsafe impl ZeroableInOption for NonZeroU8 {}
+unsafe impl ZeroableInOption for NonZeroU16 {}
+unsafe impl ZeroableInOption for NonZeroU32 {}
+unsafe impl ZeroableInOption for NonZeroU64 {}
+unsafe impl ZeroableInOption for NonZeroU128 {}
+unsafe impl ZeroableInOption for NonZeroUsize {}
 
 unsafe impl<T> Zeroable for *mut T {}
 unsafe impl<T> Zeroable for *const T {}
-unsafe impl<T> Zeroable for Option<NonNull<T>> {}
+unsafe impl<T> ZeroableInOption for NonNull<T> {}
 unsafe impl<T: Zeroable> Zeroable for PhantomData<T> {}
 unsafe impl Zeroable for PhantomPinned {}
 unsafe impl<T: Zeroable> Zeroable for ManuallyDrop<T> {}


### PR DESCRIPTION
* same as Zeroable and Pod but for types which are Zeroable and Pod when
  wrapped in Option
* allows downstream users to implement Zeroable and Pod for their own
  Option<T> types without running into orphan rules

closes #112 