### PR TITLE
Avoid `clippy::missing_const_for_fn`

### DIFF
--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -510,6 +510,7 @@ fn generate_fields_are_trait(
   let span = input.span();
   let field_types = get_field_types(&fields);
   Ok(quote_spanned! {span => #(const _: fn() = || {
+      #[allow(clippy::missing_const_for_fn)]
       fn check #impl_generics () #where_clause {
         fn assert_impl<T: #trait_>() {}
         assert_impl::<#field_types>();


### PR DESCRIPTION
I'm not sure what the MSRV for `bytemuck_derive`. `bytemuck` says that the MSRV is 1.34, but `bytemuck_derive` dosn't compile for 1.34.

So alternatively, I could just change these function to `const` if a MSRV of 1.61 for `bytemuck_derive` is okay.

I fully understand if this PR isn't desirable, as it's just mitigating false-positives from Clippy.

See https://github.com/rust-lang/rust-clippy/issues/8854.