### PR TITLE
Fix/syn broken semver

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 
 [dependencies]
 # syn seems to have broken backwards compability in this version https://github.com/dtolnay/syn/issues/1194
-syn = "1.0.6"
+syn = "1.0.15"
 quote = "1"
 proc-macro2 = "1"
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,7 +15,8 @@ name = "bytemuck_derive"
 proc-macro = true
 
 [dependencies]
-syn = "1"
+# syn seems to have broken backwards compability in this version https://github.com/dtolnay/syn/issues/1194
+syn = "1.0.6"
 quote = "1"
 proc-macro2 = "1"
 


### PR DESCRIPTION
I am working on adding bytemuck to drm-rs and they have a check in their CI which pulls minimal possible dependency versions for each crate - this check fails because syn seems to have broken semver versioning (multiple times). The check result is here https://github.com/Smithay/drm-rs/runs/7126146546?check_suite_focus=true#step:7:157

I have opened a issue https://github.com/dtolnay/syn/issues/1194 in syn about this, but in the meantime I think the obvious fix is to bump the version requirement in Cargo.toml to the lowest version at which it starts passing - this seems to be 1.0.15 to me (tested locally). The obvious missing API issues get resolved in 1.0.6 but the tests only start passing after this change https://github.com/dtolnay/syn/compare/1.0.14...1.0.15#diff-ce4e3f87da05491a74818b9736b02d9c40274befb1e2c13f44c6995eb001b925R1436 in 1.0.15.

