### PR TITLE
Add `cast_{arc,rc}` (and slice and try), and `{wrap,peel}_{arc,rc}`.

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -319,7 +319,9 @@ pub fn pod_collect_to_vec<
 
 /// As [`try_cast_rc`](try_cast_rc), but unwraps for you.
 #[inline]
-pub fn cast_rc<A: NoUninit, B: AnyBitPattern>(input: Rc<A>) -> Rc<B> {
+pub fn cast_rc<A: NoUninit + AnyBitPattern, B: NoUninit + AnyBitPattern>(
+  input: Rc<A>,
+) -> Rc<B> {
   try_cast_rc(input).map_err(|(e, _v)| e).unwrap()
 }
 
@@ -327,13 +329,17 @@ pub fn cast_rc<A: NoUninit, B: AnyBitPattern>(input: Rc<A>) -> Rc<B> {
 ///
 /// On failure you get back an error along with the starting `Rc`.
 ///
+/// The bounds on this function are the same as [`cast_mut`], because a user
+/// could call `Rc::get_unchecked_mut` on the output, which could be observable
+/// in the input.
+///
 /// ## Failure
 ///
 /// * The start and end content type of the `Rc` must have the exact same
 ///   alignment.
 /// * The start and end size of the `Rc` must have the exact same size.
 #[inline]
-pub fn try_cast_rc<A: NoUninit, B: AnyBitPattern>(
+pub fn try_cast_rc<A: NoUninit + AnyBitPattern, B: NoUninit + AnyBitPattern>(
   input: Rc<A>,
 ) -> Result<Rc<B>, (PodCastError, Rc<A>)> {
   if align_of::<A>() != align_of::<B>() {
@@ -349,7 +355,9 @@ pub fn try_cast_rc<A: NoUninit, B: AnyBitPattern>(
 
 /// As [`try_cast_arc`](try_cast_arc), but unwraps for you.
 #[inline]
-pub fn cast_arc<A: NoUninit, B: AnyBitPattern>(input: Arc<A>) -> Arc<B> {
+pub fn cast_arc<A: NoUninit + AnyBitPattern, B: NoUninit + AnyBitPattern>(
+  input: Arc<A>,
+) -> Arc<B> {
   try_cast_arc(input).map_err(|(e, _v)| e).unwrap()
 }
 
@@ -357,13 +365,20 @@ pub fn cast_arc<A: NoUninit, B: AnyBitPattern>(input: Arc<A>) -> Arc<B> {
 ///
 /// On failure you get back an error along with the starting `Arc`.
 ///
+/// The bounds on this function are the same as [`cast_mut`], because a user
+/// could call `Rc::get_unchecked_mut` on the output, which could be observable
+/// in the input.
+///
 /// ## Failure
 ///
 /// * The start and end content type of the `Arc` must have the exact same
 ///   alignment.
 /// * The start and end size of the `Arc` must have the exact same size.
 #[inline]
-pub fn try_cast_arc<A: NoUninit, B: AnyBitPattern>(
+pub fn try_cast_arc<
+  A: NoUninit + AnyBitPattern,
+  B: NoUninit + AnyBitPattern,
+>(
   input: Arc<A>,
 ) -> Result<Arc<B>, (PodCastError, Arc<A>)> {
   if align_of::<A>() != align_of::<B>() {
@@ -379,13 +394,22 @@ pub fn try_cast_arc<A: NoUninit, B: AnyBitPattern>(
 
 /// As [`try_cast_slice_rc`](try_cast_slice_rc), but unwraps for you.
 #[inline]
-pub fn cast_slice_rc<A: NoUninit, B: AnyBitPattern>(input: Rc<[A]>) -> Rc<[B]> {
+pub fn cast_slice_rc<
+  A: NoUninit + AnyBitPattern,
+  B: NoUninit + AnyBitPattern,
+>(
+  input: Rc<[A]>,
+) -> Rc<[B]> {
   try_cast_slice_rc(input).map_err(|(e, _v)| e).unwrap()
 }
 
 /// Attempts to cast the content type of a `Rc<[T]>`.
 ///
 /// On failure you get back an error along with the starting `Rc<[T]>`.
+///
+/// The bounds on this function are the same as [`cast_mut`], because a user
+/// could call `Rc::get_unchecked_mut` on the output, which could be observable
+/// in the input.
 ///
 /// ## Failure
 ///
@@ -394,7 +418,10 @@ pub fn cast_slice_rc<A: NoUninit, B: AnyBitPattern>(input: Rc<[A]>) -> Rc<[B]> {
 /// * The start and end content size in bytes of the `Rc<[T]>` must be the exact
 ///   same.
 #[inline]
-pub fn try_cast_slice_rc<A: NoUninit, B: AnyBitPattern>(
+pub fn try_cast_slice_rc<
+  A: NoUninit + AnyBitPattern,
+  B: NoUninit + AnyBitPattern,
+>(
   input: Rc<[A]>,
 ) -> Result<Rc<[B]>, (PodCastError, Rc<[A]>)> {
   if align_of::<A>() != align_of::<B>() {
@@ -429,7 +456,10 @@ pub fn try_cast_slice_rc<A: NoUninit, B: AnyBitPattern>(
 
 /// As [`try_cast_slice_arc`](try_cast_slice_arc), but unwraps for you.
 #[inline]
-pub fn cast_slice_arc<A: NoUninit, B: AnyBitPattern>(
+pub fn cast_slice_arc<
+  A: NoUninit + AnyBitPattern,
+  B: NoUninit + AnyBitPattern,
+>(
   input: Arc<[A]>,
 ) -> Arc<[B]> {
   try_cast_slice_arc(input).map_err(|(e, _v)| e).unwrap()
@@ -439,6 +469,10 @@ pub fn cast_slice_arc<A: NoUninit, B: AnyBitPattern>(
 ///
 /// On failure you get back an error along with the starting `Arc<[T]>`.
 ///
+/// The bounds on this function are the same as [`cast_mut`], because a user
+/// could call `Rc::get_unchecked_mut` on the output, which could be observable
+/// in the input.
+///
 /// ## Failure
 ///
 /// * The start and end content type of the `Arc<[T]>` must have the exact same
@@ -446,7 +480,10 @@ pub fn cast_slice_arc<A: NoUninit, B: AnyBitPattern>(
 /// * The start and end content size in bytes of the `Arc<[T]>` must be the
 ///   exact same.
 #[inline]
-pub fn try_cast_slice_arc<A: NoUninit, B: AnyBitPattern>(
+pub fn try_cast_slice_arc<
+  A: NoUninit + AnyBitPattern,
+  B: NoUninit + AnyBitPattern,
+>(
   input: Arc<[A]>,
 ) -> Result<Arc<[B]>, (PodCastError, Arc<[A]>)> {
   if align_of::<A>() != align_of::<B>() {

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -13,10 +13,10 @@ use super::*;
 use alloc::{
   alloc::{alloc_zeroed, Layout},
   boxed::Box,
-  vec,
-  vec::Vec,
   rc::Rc,
   sync::Arc,
+  vec,
+  vec::Vec,
 };
 use core::convert::TryInto;
 
@@ -379,9 +379,7 @@ pub fn try_cast_arc<A: NoUninit, B: AnyBitPattern>(
 
 /// As [`try_cast_slice_rc`](try_cast_slice_rc), but unwraps for you.
 #[inline]
-pub fn cast_slice_rc<A: NoUninit, B: AnyBitPattern>(
-  input: Rc<[A]>,
-) -> Rc<[B]> {
+pub fn cast_slice_rc<A: NoUninit, B: AnyBitPattern>(input: Rc<[A]>) -> Rc<[B]> {
   try_cast_slice_rc(input).map_err(|(e, _v)| e).unwrap()
 }
 
@@ -393,8 +391,8 @@ pub fn cast_slice_rc<A: NoUninit, B: AnyBitPattern>(
 ///
 /// * The start and end content type of the `Rc<[T]>` must have the exact same
 ///   alignment.
-/// * The start and end content size in bytes of the `Rc<[T]>` must be the
-///   exact same.
+/// * The start and end content size in bytes of the `Rc<[T]>` must be the exact
+///   same.
 #[inline]
 pub fn try_cast_slice_rc<A: NoUninit, B: AnyBitPattern>(
   input: Rc<[A]>,
@@ -419,8 +417,7 @@ pub fn try_cast_slice_rc<A: NoUninit, B: AnyBitPattern>(
       // Must use ptr::slice_from_raw_parts, because we cannot make an
       // intermediate const reference, because it has mutable provenance,
       // nor an intermediate mutable reference, because it could be aliased.
-      let ptr =
-        unsafe { core::ptr::slice_from_raw_parts(rc_ptr as *const B, length) };
+      let ptr = core::ptr::slice_from_raw_parts(rc_ptr as *const B, length);
       Ok(unsafe { Rc::<[B]>::from_raw(ptr) })
     }
   } else {
@@ -472,8 +469,7 @@ pub fn try_cast_slice_arc<A: NoUninit, B: AnyBitPattern>(
       // Must use ptr::slice_from_raw_parts, because we cannot make an
       // intermediate const reference, because it has mutable provenance,
       // nor an intermediate mutable reference, because it could be aliased.
-      let ptr =
-        unsafe { core::ptr::slice_from_raw_parts(arc_ptr as *const B, length) };
+      let ptr = core::ptr::slice_from_raw_parts(arc_ptr as *const B, length);
       Ok(unsafe { Arc::<[B]>::from_raw(ptr) })
     }
   } else {
@@ -532,8 +528,8 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
     }
   }
 
-  /// Convert an [`Rc`](alloc::rc::Rc) to the inner type into an `Rc` to the wrapper
-  /// type.
+  /// Convert an [`Rc`](alloc::rc::Rc) to the inner type into an `Rc` to the
+  /// wrapper type.
   #[inline]
   fn wrap_rc(s: Rc<Inner>) -> Rc<Self> {
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
@@ -546,7 +542,7 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
       // SAFETY:
       // * The unsafe contract requires that pointers to Inner and Self have
       //   identical representations, and that the size and alignment of Inner
-      //   and Self are the same, which meets the safety requirements of 
+      //   and Self are the same, which meets the safety requirements of
       //   Rc::from_raw
       let inner_ptr: *const Inner = Rc::into_raw(s);
       let wrapper_ptr: *const Self = transmute!(inner_ptr);
@@ -554,8 +550,8 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
     }
   }
 
-  /// Convert an [`Arc`](alloc::sync::Arc) to the inner type into an `Arc` to the wrapper
-  /// type.
+  /// Convert an [`Arc`](alloc::sync::Arc) to the inner type into an `Arc` to
+  /// the wrapper type.
   #[inline]
   fn wrap_arc(s: Arc<Inner>) -> Arc<Self> {
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
@@ -568,7 +564,7 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
       // SAFETY:
       // * The unsafe contract requires that pointers to Inner and Self have
       //   identical representations, and that the size and alignment of Inner
-      //   and Self are the same, which meets the safety requirements of 
+      //   and Self are the same, which meets the safety requirements of
       //   Arc::from_raw
       let inner_ptr: *const Inner = Arc::into_raw(s);
       let wrapper_ptr: *const Self = transmute!(inner_ptr);
@@ -621,8 +617,8 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
     }
   }
 
-  /// Convert an [`Rc`](alloc::rc::Rc) to the wrapper type into an `Rc` to the inner
-  /// type.
+  /// Convert an [`Rc`](alloc::rc::Rc) to the wrapper type into an `Rc` to the
+  /// inner type.
   #[inline]
   fn peel_rc(s: Rc<Self>) -> Rc<Inner> {
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
@@ -635,7 +631,7 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
       // SAFETY:
       // * The unsafe contract requires that pointers to Inner and Self have
       //   identical representations, and that the size and alignment of Inner
-      //   and Self are the same, which meets the safety requirements of 
+      //   and Self are the same, which meets the safety requirements of
       //   Rc::from_raw
       let wrapper_ptr: *const Self = Rc::into_raw(s);
       let inner_ptr: *const Inner = transmute!(wrapper_ptr);
@@ -643,8 +639,8 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
     }
   }
 
-  /// Convert an [`Arc`](alloc::sync::Arc) to the wrapper type into an `Arc` to the inner
-  /// type.
+  /// Convert an [`Arc`](alloc::sync::Arc) to the wrapper type into an `Arc` to
+  /// the inner type.
   #[inline]
   fn peel_arc(s: Arc<Self>) -> Arc<Inner> {
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
@@ -657,7 +653,7 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
       // SAFETY:
       // * The unsafe contract requires that pointers to Inner and Self have
       //   identical representations, and that the size and alignment of Inner
-      //   and Self are the same, which meets the safety requirements of 
+      //   and Self are the same, which meets the safety requirements of
       //   Arc::from_raw
       let wrapper_ptr: *const Self = Arc::into_raw(s);
       let inner_ptr: *const Inner = transmute!(wrapper_ptr);

--- a/tests/transparent.rs
+++ b/tests/transparent.rs
@@ -77,8 +77,7 @@ fn test_transparent_wrapper() {
   #[cfg(feature = "extern_crate_alloc")]
   {
     use bytemuck::allocation::TransparentWrapperAlloc;
-    use std::rc::Rc;
-    use std::sync::Arc;
+    use std::{rc::Rc, sync::Arc};
 
     let a: Vec<Foreign> = vec![Foreign::default(); 2];
 

--- a/tests/transparent.rs
+++ b/tests/transparent.rs
@@ -77,6 +77,8 @@ fn test_transparent_wrapper() {
   #[cfg(feature = "extern_crate_alloc")]
   {
     use bytemuck::allocation::TransparentWrapperAlloc;
+    use std::rc::Rc;
+    use std::sync::Arc;
 
     let a: Vec<Foreign> = vec![Foreign::default(); 2];
 
@@ -92,5 +94,19 @@ fn test_transparent_wrapper() {
     assert_eq!(&*e, &0);
     let f: Box<Foreign> = Wrapper::peel_box(e);
     assert_eq!(&*f, &0);
+
+    let g: Rc<Foreign> = Rc::new(Foreign::default());
+
+    let h: Rc<Wrapper> = Wrapper::wrap_rc(g);
+    assert_eq!(&*h, &0);
+    let i: Rc<Foreign> = Wrapper::peel_rc(h);
+    assert_eq!(&*i, &0);
+
+    let j: Arc<Foreign> = Arc::new(Foreign::default());
+
+    let k: Arc<Wrapper> = Wrapper::wrap_arc(j);
+    assert_eq!(&*k, &0);
+    let l: Arc<Foreign> = Wrapper::peel_arc(k);
+    assert_eq!(&*l, &0);
   }
 }


### PR DESCRIPTION
Add `allocation::{try_,}cast_{arc,rc}` (and corresponding slice functions), and `allocation::TransparentWrapperAlloc::{wrap,peel}_{arc,rc}`.

May fix #131 .

Mostly a copy-paste of the `*_box` functions, with relevant safety comments/changes (and using `*const` instead of `*mut`).

Added tests for `{wrap,peel}_{arc,rc}` where the existing tests for `{wrap,peel}_box` are. I didn't add tests for the other functions (yet).

Possible future work:
* Equivalent functions for `rc::Weak` and `sync::Weak`; 
   * Bikeshedding the names (`cast_weak_rc` vs `cast_rc_weak`)
   * For `{cast,wrap,peel}_weak_{arc,rc}`, these would be mostly copy-pastes of `*_{arc,rc}` etc.
   * For `cast_weak_slice`, these would need manual handling of length, since you can't use `input.len()`
* `zeroed_{arc,rc}` and `zeroed_slice_{arc,rc}`. These cannot be implemented manually like `zeroed_box` was, and would need to be behind an additional nightly-only feature, since `{Rc,Arc}::new_zeroed{,_slice}` are in `feature(new_uninit)`
* `try_zeroed_{arc,rc}`. These also cannot be implemented manually, and would need to be behind an additional nightly-only feature(s?), since `{Rc,Arc}::new_zeroed_slice` are in `feature(allocator_api)` (and/or `feature(new_uninit)`, depending on which gets stabilized first).
* `try_zeroed_slice_{arc,rc}`. The corresponding functions currently do not currently exist in the stdlib.
* Note: the `*_zeroed_*` could be implemented (less efficiently) in terms of their `_box` counterparts, using `impl<T: ?Sized> From<Box<T>> for Rc<T>/Arc<T>`. These impls are from `1.21.0`, so it would not require a nightly-oly feature nor raise the MSRV of using the `extern_crate_alloc` feature (Sidenote: Does this crate keep MSRVs for specific features?).