### PR TITLE
WIP/proof-of-concept: refactor `Box`/`Rc`/`Arc` to reduce code duplication.

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -45,6 +45,337 @@ pub(crate) fn something_went_wrong<D>(_src: &str, _err: D) -> ! {
   panic!("Called a panicing helper from bytemuck which paniced");
 }
 
+/// # Safety
+///
+/// Must only be implemented on types where it is valid to pass a
+/// pointer to from_raw that came from into_raw on a different instantiation of
+/// the same ADT, e.g.
+/// ```rs
+/// let ptr: *mut U = <MyPointer<U> as CastablePointer<U>>::into_raw(my_pointer);
+/// let new_ptr: *mut T = / cast ptr to *mut T upholding the invariants below */;
+/// let my_new_pointer = <MyPointer<T> as CastablePointer<T>>::from_raw(new_ptr);
+/// ```
+///
+/// For all implementors, it must be valid to pass the same pointer returned
+/// from `Self::into_raw(self)` (uncasted) back to `Self::from_raw(ptr)` to get
+/// `self` back.
+///
+/// Looser requirements are given by subtraits. In particular, changing the
+/// pointee type is generally allowed as long as layout invariants and
+/// bytemuck's castability trait invariants are upheld.
+pub(crate) unsafe trait CastablePointer<T: ?Sized> {
+  /// Return a pointer that can be given to `Self<U>::from_raw``, if all other
+  /// invariants hold. This pointer should not dereferenced, as it may be
+  /// invalid for anything other than passing to from_raw. (e.g. it may actually
+  /// be a `*const T``, or it may point to a dropped T that has not been
+  /// deallocated.)
+  fn into_raw(self) -> *mut T;
+  /// # Safety
+  ///
+  /// `ptr` must have come from CastablePointer::into_raw on the same ADT
+  /// (e.g. `Box<T>` -> `Box<U>`, `&'a T` -> `&'a U`), and any additional
+  /// invariants of the ADT must be upheld. See the ADT's particular
+  /// `AdjectiveCastablePointer` impls' documentation for those invariants.
+  unsafe fn from_raw(ptr: *mut T) -> Self;
+}
+
+/// This marker trait indicates that a [`CastablePointer`] is a borrowed
+/// pointer.
+///
+/// # Safety
+///
+/// * `CastablePointer::from_raw` must accept pointers where the pointee has the
+///   same size as the `into_raw`'d pointee, and the pointer is validly aligned
+///   for `Self`'s pointee.
+/// * Additional castability invariants on the pointee (e.g. NoUninit) must also
+///   be upheld.
+pub(crate) unsafe trait BorrowedCastablePointer {}
+
+/// This marker trait indicates that a [`CastablePointer`] is an owned
+/// pointer.
+///
+/// # Safety
+///
+/// * `from_raw` must accept pointers where the pointee has the same layout
+///   (size and alignment) as the `into_raw`'d pointee.
+/// * Additional castability invariants on the pointee (e.g. NoUninit) must also
+///   be upheld.
+#[cfg(feature = "extern_crate_alloc")]
+pub(crate) unsafe trait OwnedCastablePointer {}
+
+unsafe impl<'a, T: ?Sized> CastablePointer<T> for &'a T {
+  #[inline]
+  fn into_raw(self) -> *mut T {
+    self as *const T as *mut T
+  }
+
+  #[inline]
+  unsafe fn from_raw(ptr: *mut T) -> Self {
+    &*(ptr as *const T)
+  }
+}
+
+unsafe impl<'a, T: ?Sized> CastablePointer<T> for &'a mut T {
+  #[inline]
+  fn into_raw(self) -> *mut T {
+    self as *mut T
+  }
+
+  #[inline]
+  unsafe fn from_raw(ptr: *mut T) -> Self {
+    &mut *ptr
+  }
+}
+
+unsafe impl<'a, T: ?Sized> BorrowedCastablePointer for &'a T {}
+unsafe impl<'a, T: ?Sized> BorrowedCastablePointer for &'a mut T {}
+
+/// Attempts to cast the content type of an owned `CastablePointer<T>`.
+///
+/// On failure you get back an error along with the starting `CastablePointer`.
+///
+/// ## Failure
+///
+/// * The start and end pointee type must have the exact same size and
+///   alignment.
+///
+/// ## Safety
+///
+/// * `AP` and `BP` must be instantiations of the same ADT with `A` and `B`,
+///   respectively (e.g. `Box<A>` and `Box<B>`).
+/// * The invariants on A and B (e.g. NoUninit) must be upheld by the caller.
+#[cfg(feature = "extern_crate_alloc")]
+#[inline]
+pub(crate) unsafe fn try_cast_owned_ptr<
+  A: Copy,
+  B: Copy,
+  AP: CastablePointer<A> + OwnedCastablePointer,
+  BP: CastablePointer<B> + OwnedCastablePointer,
+>(
+  input: AP,
+) -> Result<BP, (PodCastError, AP)> {
+  if align_of::<A>() != align_of::<B>() {
+    Err((PodCastError::AlignmentMismatch, input))
+  } else if size_of::<A>() != size_of::<B>() {
+    Err((PodCastError::SizeMismatch, input))
+  } else {
+    // Safety: we uphold the requirements of OwnedCastablePointer because `A`
+    // and `B` have the same layout. Castability invariants on A
+    // and B are upheld by our caller.
+    unsafe {
+      let ptr: *mut A = CastablePointer::into_raw(input);
+      Ok(CastablePointer::from_raw(ptr as *mut B))
+    }
+  }
+}
+
+/// Try to convert an owned `CastablePointer<[A]>` into `CastablePointer<[B]>`
+/// (possibly with a change in length).
+///
+/// * `input.as_ptr() as usize == output.as_ptr() as usize`
+/// * `input.len() * size_of::<A>() == output.len() * size_of::<B>()`
+///
+/// ## Failure
+///
+/// * The start and end content type of the `CastablePointer<[T]>` must have the
+///   exact same alignment.
+/// * The start and end content size in bytes of the `CastablePointer<[T]>` must
+///   be the exact same.
+///
+/// ## Safety
+///
+/// * `AP` and `BP` must be instantiations of the same ADT (e.g. `Box<[A]>` and
+///   `Box<[B]>`).
+/// * The castabilty invariants on A and B, if any (e.g. NoUninit) must be
+///   upheld by the caller.
+///
+/// TODO: if we want to support Weak, we'd have to remove the Deref bound and
+/// get the length from the pointer directly, but that is not possible in
+/// bytemuck's MSRV, so would have to be under a feature flag.
+#[cfg(feature = "extern_crate_alloc")]
+#[inline]
+pub(crate) unsafe fn try_cast_owned_slice_ptr<
+  A: Copy,
+  B: Copy,
+  AP: CastablePointer<[A]> + OwnedCastablePointer + core::ops::Deref<Target = [A]>,
+  BP: CastablePointer<[B]> + OwnedCastablePointer,
+>(
+  input: AP,
+) -> Result<BP, (PodCastError, AP)> {
+  if align_of::<A>() != align_of::<B>() {
+    Err((PodCastError::AlignmentMismatch, input))
+  } else if size_of::<A>() != size_of::<B>() {
+    let input_bytes = size_of_val::<[A]>(&*input);
+    if (size_of::<B>() == 0 && input_bytes != 0)
+      || (size_of::<B>() != 0 && input_bytes % size_of::<B>() != 0)
+    {
+      // If the size in bytes of the underlying buffer does not match an exact
+      // multiple of the size of B, we cannot cast between them.
+      Err((PodCastError::OutputSliceWouldHaveSlop, input))
+    } else {
+      // Because the size is an exact multiple, we can now change the length
+      // of the slice and recreate the pointer.
+      let length =
+        if size_of::<B>() != 0 { input_bytes / size_of::<B>() } else { 0 };
+      let ptr: *mut [A] = CastablePointer::into_raw(input);
+      let ptr: *mut [B] =
+        core::ptr::slice_from_raw_parts_mut(ptr as *mut B, length);
+      // Safety: We uphold the requirements of OwnedCastablePointer because *ptr
+      // has the same size as before, and `A` and `B` have the same alignemnt.
+      unsafe { Ok(CastablePointer::from_raw(ptr)) }
+    }
+  } else {
+    // Safety: we uphold the requirements of OwnedCastablePointer because `A`
+    // and `B` have the same layout and we did not change the slice length.
+    // Castability invariants on A and B are upheld by our caller.
+    unsafe {
+      let ptr: *mut [A] = CastablePointer::into_raw(input);
+      Ok(CastablePointer::from_raw(ptr as *mut [B]))
+    }
+  }
+}
+
+/// Attempts to cast the content type of an `CastablePointer<T>`. The alignment
+/// of `A` and `B` need not be the same as long as `input` is validly aligned
+/// for `B`.
+///
+/// On failure you get back an error along with the starting `CastablePointer`.
+///
+/// ## Failure
+///
+/// * The start and end pointee type must have the exact same size.
+///
+/// ## Safety
+///
+/// * `AP` and `BP` must be instantiations of the same ADT with `A` and `B`,
+///   respectively (e.g. `Box<A>` and `Box<B>`) such that `from_raw` is valid to
+///   pass same-size types where the pointer is validly aligned for the
+///   destination type.
+/// * The pointer returned from `AP::into_raw` must be aligned for `A`.
+/// * The invariants on A and B (e.g. NoUninit) must be upheld by the caller.
+#[inline]
+pub(crate) unsafe fn try_cast_borrowed_ptr<
+  A: Copy,
+  B: Copy,
+  AP: CastablePointer<A> + BorrowedCastablePointer,
+  BP: CastablePointer<B> + BorrowedCastablePointer,
+>(
+  input: AP,
+) -> Result<BP, (PodCastError, AP)> {
+  if size_of::<A>() != size_of::<B>() {
+    Err((PodCastError::SizeMismatch, input))
+  } else {
+    let ptr: *mut A = CastablePointer::into_raw(input);
+    // only do the alignment check if it could fail
+    if align_of::<A>() >= align_of::<B>()
+      || is_aligned_to(ptr as *const (), align_of::<B>())
+    {
+      // Safety: same size, and the pointer is aligned. Other invariants are
+      // upheld by our caller.
+      unsafe { Ok(CastablePointer::from_raw(ptr as *mut B)) }
+    } else {
+      // Cannot cast unaligned pointer to more-aligned type.
+      // Safety: AP::from_raw(AP::into_raw(ptr)) is always safe.
+      Err((PodCastError::TargetAlignmentGreaterAndInputNotAligned, unsafe {
+        CastablePointer::from_raw(ptr)
+      }))
+    }
+  }
+}
+
+/// Try to convert `CastablePointer<[A]>` into `CastablePointer<[B]>` (possibly
+/// with a change in length). The alignment of `A` and `B` need not be the same
+/// as long as `input` is validly aligned for `B`.
+///
+/// * `input.as_ptr() as usize == output.as_ptr() as usize`
+/// * `input.len() * size_of::<A>() == output.len() * size_of::<B>()`
+///
+/// ## Failure
+///
+/// * The start and end content size in bytes of the `CastablePointer<[T]>` must
+///   be the exact same.
+///
+/// ## Safety
+///
+/// * `AP` and `BP` must be instantiations of the same ADT with `[A]` and `[B]`
+///   (e.g. `Box<[A]>` and `Box<[B]>`) such that `from_raw` is valid to pass
+///   same-size types where the pointer is validly aligned for the destination
+///   type.
+/// * The pointer returned from `AP::into_raw` must be aligned for `A`.
+/// * The invariants on A and B, if any (e.g. NoUninit) must be upheld by the
+///   caller.
+///
+/// TODO: if we want to support Weak, we'd have to remove the Deref bound and
+/// get the length from the pointer directly, but that is not possible in
+/// bytemuck's MSRV, so would have to be under a feature flag.
+#[inline]
+unsafe fn try_cast_borrowed_slice_ptr<
+  A: Copy,
+  B: Copy,
+  AP: CastablePointer<[A]>
+    + BorrowedCastablePointer
+    + core::ops::Deref<Target = [A]>,
+  BP: CastablePointer<[B]> + BorrowedCastablePointer,
+>(
+  input: AP,
+) -> Result<BP, (PodCastError, AP)> {
+  if size_of::<A>() != size_of::<B>() {
+    let input_bytes = size_of::<A>() * input.len();
+    if (size_of::<B>() == 0 && input_bytes != 0)
+      || (size_of::<B>() != 0 && input_bytes % size_of::<B>() != 0)
+    {
+      // If the size in bytes of the underlying buffer does not match an exact
+      // multiple of the size of B, we cannot cast between them.
+      Err((PodCastError::OutputSliceWouldHaveSlop, input))
+    } else {
+      let length = if size_of::<B>() != 0 {
+        size_of::<A>() * input.len() / size_of::<B>()
+      } else {
+        0
+      };
+      let ptr: *mut [A] = CastablePointer::into_raw(input);
+      // only do the alignment check if it could fail
+      if align_of::<A>() >= align_of::<B>()
+        || is_aligned_to(ptr as *const (), align_of::<B>())
+      {
+        // Because the size is an exact multiple, we can now change the length
+        // of the slice and recreate the pointer.
+        // NOTE: This is a valid operation because according to the contract of
+        // CastablePointer, the size in bytes and type alignment must be the
+        // same. The invariants on A and B must be upheld by our caller.
+        let ptr: *mut [B] =
+          core::ptr::slice_from_raw_parts_mut(ptr as *mut B, length);
+        unsafe { Ok(CastablePointer::from_raw(ptr)) }
+      } else {
+        // Cannot cast unaligned pointer to more-aligned type.
+        // Safety: AP::from_raw(AP::into_raw(ptr)) is always safe.
+        Err((PodCastError::TargetAlignmentGreaterAndInputNotAligned, unsafe {
+          CastablePointer::from_raw(ptr)
+        }))
+      }
+    }
+  } else {
+    let ptr: *mut [A] = CastablePointer::into_raw(input);
+    // only do the alignment check if it could fail
+    if align_of::<A>() >= align_of::<B>()
+      || is_aligned_to(ptr as *const (), align_of::<B>())
+    {
+      // Because the size is the same, we can recreate the pointer without
+      // changing the length. NOTE: This is a valid operation because
+      // according to the contract of CastablePointer, the size in bytes
+      // and type alignment must be the same. The invariants on A and B
+      // must be upheld by our caller.
+      unsafe { Ok(CastablePointer::from_raw(ptr as *mut [B])) }
+    } else {
+      // Cannot cast unaligned pointer to more-aligned type.
+      // Safety: AP::from_raw(AP::into_raw(ptr)) is always safe.
+      Err((PodCastError::TargetAlignmentGreaterAndInputNotAligned, unsafe {
+        CastablePointer::from_raw(ptr)
+      }))
+    }
+  }
+}
+
 /// Re-interprets `&T` as `&[u8]`.
 ///
 /// Any ZST becomes an empty slice, and in that case the pointer value of that
@@ -301,17 +632,10 @@ pub(crate) unsafe fn try_cast<A: Copy, B: Copy>(
 pub(crate) unsafe fn try_cast_ref<A: Copy, B: Copy>(
   a: &A,
 ) -> Result<&B, PodCastError> {
-  // Note(Lokathor): everything with `align_of` and `size_of` will optimize away
-  // after monomorphization.
-  if align_of::<B>() > align_of::<A>()
-    && !is_aligned_to(a as *const A as *const (), align_of::<B>())
-  {
-    Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
-  } else if size_of::<B>() == size_of::<A>() {
-    Ok(unsafe { &*(a as *const A as *const B) })
-  } else {
-    Err(PodCastError::SizeMismatch)
-  }
+  // Safety: `&A` and `&B` are valid to cast between under the requirements of
+  // try_cast_ptr. Additional invariants on `A` and `B` are upheld by our
+  // caller.
+  unsafe { try_cast_borrowed_ptr(a) }.map_err(|(err, _)| err)
 }
 
 /// Try to convert a `&mut T` into `&mut U`.
@@ -321,17 +645,10 @@ pub(crate) unsafe fn try_cast_ref<A: Copy, B: Copy>(
 pub(crate) unsafe fn try_cast_mut<A: Copy, B: Copy>(
   a: &mut A,
 ) -> Result<&mut B, PodCastError> {
-  // Note(Lokathor): everything with `align_of` and `size_of` will optimize away
-  // after monomorphization.
-  if align_of::<B>() > align_of::<A>()
-    && !is_aligned_to(a as *const A as *const (), align_of::<B>())
-  {
-    Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
-  } else if size_of::<B>() == size_of::<A>() {
-    Ok(unsafe { &mut *(a as *mut A as *mut B) })
-  } else {
-    Err(PodCastError::SizeMismatch)
-  }
+  // Safety: `&mut A` and `&mut B` are valid to cast between under the
+  // requirements of try_cast_ptr. Additional invariants on `A` and `B` are
+  // upheld by our caller.
+  unsafe { try_cast_borrowed_ptr(a) }.map_err(|(err, _)| err)
 }
 
 /// Try to convert `&[A]` into `&[B]` (possibly with a change in length).
@@ -353,22 +670,10 @@ pub(crate) unsafe fn try_cast_mut<A: Copy, B: Copy>(
 pub(crate) unsafe fn try_cast_slice<A: Copy, B: Copy>(
   a: &[A],
 ) -> Result<&[B], PodCastError> {
-  // Note(Lokathor): everything with `align_of` and `size_of` will optimize away
-  // after monomorphization.
-  if align_of::<B>() > align_of::<A>()
-    && !is_aligned_to(a.as_ptr() as *const (), align_of::<B>())
-  {
-    Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
-  } else if size_of::<B>() == size_of::<A>() {
-    Ok(unsafe { core::slice::from_raw_parts(a.as_ptr() as *const B, a.len()) })
-  } else if size_of::<A>() == 0 || size_of::<B>() == 0 {
-    Err(PodCastError::SizeMismatch)
-  } else if core::mem::size_of_val(a) % size_of::<B>() == 0 {
-    let new_len = core::mem::size_of_val(a) / size_of::<B>();
-    Ok(unsafe { core::slice::from_raw_parts(a.as_ptr() as *const B, new_len) })
-  } else {
-    Err(PodCastError::OutputSliceWouldHaveSlop)
-  }
+  // Safety: `&[A]` and `&[B]` are valid to cast between under the requirements
+  // of try_cast_ptr. Additional invariants on `A` and `B` are upheld by our
+  // caller.
+  unsafe { try_cast_borrowed_slice_ptr(a) }.map_err(|(err, _)| err)
 }
 
 /// Try to convert `&mut [A]` into `&mut [B]` (possibly with a change in
@@ -379,24 +684,8 @@ pub(crate) unsafe fn try_cast_slice<A: Copy, B: Copy>(
 pub(crate) unsafe fn try_cast_slice_mut<A: Copy, B: Copy>(
   a: &mut [A],
 ) -> Result<&mut [B], PodCastError> {
-  // Note(Lokathor): everything with `align_of` and `size_of` will optimize away
-  // after monomorphization.
-  if align_of::<B>() > align_of::<A>()
-    && !is_aligned_to(a.as_ptr() as *const (), align_of::<B>())
-  {
-    Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
-  } else if size_of::<B>() == size_of::<A>() {
-    Ok(unsafe {
-      core::slice::from_raw_parts_mut(a.as_mut_ptr() as *mut B, a.len())
-    })
-  } else if size_of::<A>() == 0 || size_of::<B>() == 0 {
-    Err(PodCastError::SizeMismatch)
-  } else if core::mem::size_of_val(a) % size_of::<B>() == 0 {
-    let new_len = core::mem::size_of_val(a) / size_of::<B>();
-    Ok(unsafe {
-      core::slice::from_raw_parts_mut(a.as_mut_ptr() as *mut B, new_len)
-    })
-  } else {
-    Err(PodCastError::OutputSliceWouldHaveSlop)
-  }
+  // Safety: `&mut [A]` and `&mut [B]` are valid to cast between under the
+  // requirements of try_cast_ptr. Additional invariants on `A` and `B` are
+  // upheld by our caller.
+  unsafe { try_cast_borrowed_slice_ptr(a) }.map_err(|(err, _)| err)
 }

--- a/tests/cast_slice_tests.rs
+++ b/tests/cast_slice_tests.rs
@@ -22,7 +22,7 @@ fn test_try_cast_slice() {
   );
 
   // by taking one byte off the front, we're definitely mis-aligned for u32.
-  let mis_aligned_bytes = &the_bytes[1..];
+  let mis_aligned_bytes = &the_bytes[1..][..4];
   assert_eq!(
     try_cast_slice::<u8, u32>(mis_aligned_bytes),
     Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
@@ -60,7 +60,7 @@ fn test_try_cast_slice_mut() {
   assert_eq!(u32_len * size_of::<u32>(), the_bytes_len * size_of::<u8>());
 
   // by taking one byte off the front, we're definitely mis-aligned for u32.
-  let mis_aligned_bytes = &mut the_bytes[1..];
+  let mis_aligned_bytes = &mut the_bytes[1..][..4];
   assert_eq!(
     try_cast_slice_mut::<u8, u32>(mis_aligned_bytes),
     Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)

--- a/tests/checked_tests.rs
+++ b/tests/checked_tests.rs
@@ -37,7 +37,7 @@ fn test_try_cast_slice() {
 
   // by taking one byte off the front, we're definitely mis-aligned for
   // NonZeroU32.
-  let mis_aligned_bytes = &the_bytes[1..];
+  let mis_aligned_bytes = &the_bytes[1..][..4];
   assert_eq!(
     checked::try_cast_slice::<u8, NonZeroU32>(mis_aligned_bytes),
     Err(CheckedCastError::PodCastError(
@@ -104,7 +104,7 @@ fn test_try_cast_slice_mut() {
   );
 
   // by taking one byte off the front, we're definitely mis-aligned for u32.
-  let mis_aligned_bytes = &mut the_bytes[1..];
+  let mis_aligned_bytes = &mut the_bytes[1..][..4];
   assert_eq!(
     checked::try_cast_slice_mut::<u8, NonZeroU32>(mis_aligned_bytes),
     Err(CheckedCastError::PodCastError(


### PR DESCRIPTION
WIP/proof-of-concept: As mentioned in #132, much of the code for `Box`/`Rc`/`Arc`'s functions is very similar. This WIP does not address the public API duplication mentioned in that PR and #133, but it does somewhat address the code duplication by factoring out the common code into generic `try_cast_aligned_ptr` and `try_cast_aligned_slice_ptr` functions, which use a trait `CastablePointer` to convert between smart pointer types and raw pointers.

The API is the same as #132 and is all implemented, but there are some "TODO"s in the code of things that could be added or things that could be removed.

Currently, the only changes are private, but something similar this could perhaps be made public.

Alternately to how it currrently works, the `CastablePointer<T>` trait could instead be parameterized on the "raw" type it returns, (rather than being hardcoded to have a "raw" type of `*mut T`). This could make it possible to additionally use it for `Vec`, though I don't know how useful that would be, since `Vec` needs some special handling anyway.