### PR TITLE
Fix clippy lints

### DIFF
--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -362,7 +362,11 @@ impl Derivable for Contiguous {
       quote!(),
       quote! {
           type Int = #integer_ty;
+
+          #![allow(clippy::missing_docs_in_private_items)]
           const MIN_VALUE: #integer_ty = #min_lit;
+
+          #![allow(clippy::missing_docs_in_private_items)]
           const MAX_VALUE: #integer_ty = #max_lit;
       },
     ))
@@ -429,6 +433,7 @@ fn generate_checked_bit_pattern_struct(
         #repr
         #[derive(Clone, Copy, ::bytemuck::AnyBitPattern)]
         #derive_dbg
+        #[allow(missing_docs)]
         pub struct #bits_ty {
             #(#field_name: <#field_ty as ::bytemuck::CheckedBitPattern>::Bits,)*
         }
@@ -437,7 +442,7 @@ fn generate_checked_bit_pattern_struct(
         type Bits = #bits_ty;
 
         #[inline]
-        #[allow(clippy::double_comparisons)]
+        #[allow(clippy::double_comparisons, unused)]
         fn is_valid_bit_pattern(bits: &#bits_ty) -> bool {
             #(<#field_ty as ::bytemuck::CheckedBitPattern>::is_valid_bit_pattern(&bits.#field_name) && )* true
         }

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -163,10 +163,7 @@ unsafe impl CheckedBitPattern for bool {
 
   #[inline]
   fn is_valid_bit_pattern(bits: &Self::Bits) -> bool {
-    match *bits {
-      0 | 1 => true,
-      _ => false,
-    }
+    matches!(*bits, 0 | 1)
   }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -23,7 +23,9 @@ possibility code branch.
 #[cfg(not(target_arch = "spirv"))]
 #[cold]
 #[inline(never)]
-pub(crate) fn something_went_wrong<D: core::fmt::Display>(_src: &str, _err: D) -> ! {
+pub(crate) fn something_went_wrong<D: core::fmt::Display>(
+  _src: &str, _err: D,
+) -> ! {
   // Note(Lokathor): Keeping the panic here makes the panic _formatting_ go
   // here too, which helps assembly readability and also helps keep down
   // the inline pressure.


### PR DESCRIPTION
- allows multiple clippy lints that fire from the derives in `bytemuck`