### PR TITLE
Conditionally compile in `Arc`

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -10,11 +10,12 @@
 //! ["extern_crate_alloc"]}`
 
 use super::*;
+#[cfg(target_has_atomic = "ptr")]
+use alloc::sync::Arc;
 use alloc::{
   alloc::{alloc_zeroed, Layout},
   boxed::Box,
   rc::Rc,
-  sync::Arc,
   vec,
   vec::Vec,
 };
@@ -355,6 +356,7 @@ pub fn try_cast_rc<A: NoUninit + AnyBitPattern, B: NoUninit + AnyBitPattern>(
 
 /// As [`try_cast_arc`](try_cast_arc), but unwraps for you.
 #[inline]
+#[cfg(target_has_atomic = "ptr")]
 pub fn cast_arc<A: NoUninit + AnyBitPattern, B: NoUninit + AnyBitPattern>(
   input: Arc<A>,
 ) -> Arc<B> {
@@ -375,6 +377,7 @@ pub fn cast_arc<A: NoUninit + AnyBitPattern, B: NoUninit + AnyBitPattern>(
 ///   alignment.
 /// * The start and end size of the `Arc` must have the exact same size.
 #[inline]
+#[cfg(target_has_atomic = "ptr")]
 pub fn try_cast_arc<
   A: NoUninit + AnyBitPattern,
   B: NoUninit + AnyBitPattern,
@@ -456,6 +459,7 @@ pub fn try_cast_slice_rc<
 
 /// As [`try_cast_slice_arc`](try_cast_slice_arc), but unwraps for you.
 #[inline]
+#[cfg(target_has_atomic = "ptr")]
 pub fn cast_slice_arc<
   A: NoUninit + AnyBitPattern,
   B: NoUninit + AnyBitPattern,
@@ -480,6 +484,7 @@ pub fn cast_slice_arc<
 /// * The start and end content size in bytes of the `Arc<[T]>` must be the
 ///   exact same.
 #[inline]
+#[cfg(target_has_atomic = "ptr")]
 pub fn try_cast_slice_arc<
   A: NoUninit + AnyBitPattern,
   B: NoUninit + AnyBitPattern,
@@ -590,6 +595,7 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
   /// Convert an [`Arc`](alloc::sync::Arc) to the inner type into an `Arc` to
   /// the wrapper type.
   #[inline]
+  #[cfg(target_has_atomic = "ptr")]
   fn wrap_arc(s: Arc<Inner>) -> Arc<Self> {
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
 
@@ -679,6 +685,7 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
   /// Convert an [`Arc`](alloc::sync::Arc) to the wrapper type into an `Arc` to
   /// the inner type.
   #[inline]
+  #[cfg(target_has_atomic = "ptr")]
   fn peel_arc(s: Arc<Self>) -> Arc<Inner> {
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
 

--- a/tests/transparent.rs
+++ b/tests/transparent.rs
@@ -77,7 +77,7 @@ fn test_transparent_wrapper() {
   #[cfg(feature = "extern_crate_alloc")]
   {
     use bytemuck::allocation::TransparentWrapperAlloc;
-    use std::{rc::Rc, sync::Arc};
+    use std::rc::Rc;
 
     let a: Vec<Foreign> = vec![Foreign::default(); 2];
 
@@ -101,11 +101,16 @@ fn test_transparent_wrapper() {
     let i: Rc<Foreign> = Wrapper::peel_rc(h);
     assert_eq!(&*i, &0);
 
-    let j: Arc<Foreign> = Arc::new(Foreign::default());
+    #[cfg(target_has_atomic = "ptr")]
+    {
+      use std::sync::Arc;
 
-    let k: Arc<Wrapper> = Wrapper::wrap_arc(j);
-    assert_eq!(&*k, &0);
-    let l: Arc<Foreign> = Wrapper::peel_arc(k);
-    assert_eq!(&*l, &0);
+      let j: Arc<Foreign> = Arc::new(Foreign::default());
+
+      let k: Arc<Wrapper> = Wrapper::wrap_arc(j);
+      assert_eq!(&*k, &0);
+      let l: Arc<Foreign> = Wrapper::peel_arc(k);
+      assert_eq!(&*l, &0);
+    }
   }
 }


### PR DESCRIPTION
Apparently the latest release of `bytemuck` doesn't compile on some of the targets that it used to because it uses `Arc`. `Arc` is not a type that exists on every target, because not every target supports atomics.

Error message with 1.12.2:
```
error[E0432]: unresolved import `alloc::sync`
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/bytemuck-1.12.2/src/allocation.rs:17:3
   |
17 |   sync::Arc,
   |   ^^^^ could not find `sync` in `alloc`
```