### PR TITLE
Move the array impl for `Pod` to superset types

### DIFF
--- a/src/anybitpattern.rs
+++ b/src/anybitpattern.rs
@@ -54,3 +54,13 @@ pub unsafe trait AnyBitPattern:
 }
 
 unsafe impl<T: Pod> AnyBitPattern for T {}
+
+#[cfg(not(feature = "min_const_generics"))]
+impl_unsafe_marker_for_array!(
+  AnyBitPattern, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+  20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256,
+  512, 1024, 2048, 4096
+);
+
+#[cfg(feature = "min_const_generics")]
+unsafe impl<T, const N: usize> AnyBitPattern for [T; N] where T: AnyBitPattern {}

--- a/src/no_uninit.rs
+++ b/src/no_uninit.rs
@@ -78,3 +78,13 @@ unsafe impl NoUninit for NonZeroU128 {}
 unsafe impl NoUninit for NonZeroI128 {}
 unsafe impl NoUninit for NonZeroUsize {}
 unsafe impl NoUninit for NonZeroIsize {}
+
+#[cfg(not(feature = "min_const_generics"))]
+impl_unsafe_marker_for_array!(
+  NoUninit, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+  20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256,
+  512, 1024, 2048, 4096
+);
+
+#[cfg(feature = "min_const_generics")]
+unsafe impl<T, const N: usize> NoUninit for [T; N] where T: NoUninit {}

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -66,16 +66,6 @@ unsafe impl<T: Pod> Pod for ManuallyDrop<T> {}
 
 // Note(Lokathor): MaybeUninit can NEVER be Pod.
 
-#[cfg(feature = "min_const_generics")]
-unsafe impl<T, const N: usize> Pod for [T; N] where T: Pod {}
-
-#[cfg(not(feature = "min_const_generics"))]
-impl_unsafe_marker_for_array!(
-  Pod, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-  20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256,
-  512, 1024, 2048, 4096
-);
-
 #[cfg(all(target_arch = "wasm32", feature = "wasm_simd"))]
 unsafe impl Pod for wasm32::v128 {}
 

--- a/tests/array_tests.rs
+++ b/tests/array_tests.rs
@@ -4,9 +4,22 @@ pub fn test_cast_array() {
   let _: [u16; 6] = bytemuck::cast(x);
 }
 
+#[test]
+pub fn test_cast_char_array() {
+  let x = ['h', 'e', 'l', 'l', 'o'];
+  let _: [u32; 5] = bytemuck::cast(x);
+}
+
 #[cfg(feature = "min_const_generics")]
 #[test]
 pub fn test_cast_long_array() {
   let x = [0u32; 65];
   let _: [u16; 130] = bytemuck::cast(x);
+}
+
+#[cfg(feature = "min_const_generics")]
+#[test]
+pub fn test_cast_long_char_array() {
+  let x = ['a'; 65];
+  let _: [u32; 65] = bytemuck::cast(x);
 }


### PR DESCRIPTION
This change removes the current `impl Pod for [T; N]` and moves it to superset types, namely into two other impls: `impl NonUninit for [T; N]` and `impl AnyBitPattern for [T; N]`.

This, makes it possible for the user to cast between an array of `NonUnint` and an array of `AnyBitPattern` for example, which was previously impossible. One example usecase would be to cast from`[char; N]` to `[u32; N]`.

I think this shouldn't break any existing code, since before only code with `T: Pod` would compile, and now both `T: NonUninit` and `T: AnyBitPattern` works, and those are strict supersets of `Pod`.