### PR TITLE
Remove where clause from derived TransparentWrapper impls.

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -252,6 +252,12 @@ fn derive_marker_trait_inner<Trait: Derivable>(
     quote!()
   };
 
+  let where_clause = if Trait::requires_where_clause() {
+    where_clause
+  } else {
+    None
+  };
+
   Ok(quote! {
     #asserts
 

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -32,6 +32,9 @@ pub trait Derivable {
   fn trait_impl(_input: &DeriveInput) -> Result<(TokenStream, TokenStream)> {
     Ok((quote!(), quote!()))
   }
+  fn requires_where_clause() -> bool {
+    true
+  }
 }
 
 pub struct Pod;
@@ -299,6 +302,10 @@ impl Derivable for TransparentWrapper {
         )
       }
     }
+  }
+
+  fn requires_where_clause() -> bool {
+    false
   }
 }
 

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -23,3 +23,29 @@ struct TransparentWithZeroSized {
   a: u16,
   b: (),
 }
+
+#[derive(TransparentWrapper)]
+#[repr(transparent)]
+struct TransparentWithGeneric<T> {
+  a: T,
+}
+
+/// Ensuring that no additional bounds are emitted.
+/// See https://github.com/Lokathor/bytemuck/issues/145
+fn test_generic<T>(x: T) -> TransparentWithGeneric<T> {
+  TransparentWithGeneric::wrap(x)
+}
+
+#[derive(TransparentWrapper)]
+#[repr(transparent)]
+#[transparent(T)]
+struct TransparentWithGenericAndZeroSized<T> {
+  a: T,
+  b: ()
+}
+
+/// Ensuring that no additional bounds are emitted.
+/// See https://github.com/Lokathor/bytemuck/issues/145
+fn test_generic_with_zst<T>(x: T) -> TransparentWithGenericAndZeroSized<T> {
+  TransparentWithGenericAndZeroSized::wrap(x)
+}


### PR DESCRIPTION
Remove the unnecessary `where T: TransparentWrapper<T>` bound on derived TransparentWrapper impls for generic structs.
Resolves #145 