### PR TITLE
Implement `Zeroable` on `{Cell,Reverse}<impl Zeroable>`

### DIFF
--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -41,6 +41,7 @@ unsafe impl Zeroable for i128 {}
 unsafe impl Zeroable for f32 {}
 unsafe impl Zeroable for f64 {}
 unsafe impl<T: Zeroable> Zeroable for Wrapping<T> {}
+unsafe impl<T: Zeroable> Zeroable for core::cmp::Reverse<T> {}
 
 unsafe impl<T> Zeroable for *mut T {}
 unsafe impl<T> Zeroable for *const T {}

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -48,6 +48,7 @@ unsafe impl<T: Zeroable> Zeroable for PhantomData<T> {}
 unsafe impl Zeroable for PhantomPinned {}
 unsafe impl<T: Zeroable> Zeroable for ManuallyDrop<T> {}
 unsafe impl<T: Zeroable> Zeroable for core::cell::UnsafeCell<T> {}
+unsafe impl<T: Zeroable> Zeroable for core::cell::Cell<T> {}
 
 #[cfg(feature = "zeroable_maybe_uninit")]
 unsafe impl<T> Zeroable for core::mem::MaybeUninit<T> {}


### PR DESCRIPTION
Implements `Zeroable` on additional types provided by Rust 1.34.