### PR TITLE
Make `checked::pod_read_unaligned` require `T: CheckedBitPattern`

### DIFF
--- a/src/checked.rs
+++ b/src/checked.rs
@@ -404,7 +404,7 @@ pub fn from_bytes_mut<T: NoUninit + CheckedBitPattern>(s: &mut [u8]) -> &mut T {
 /// ## Panics
 /// * This is like `try_pod_read_unaligned` but will panic on failure.
 #[inline]
-pub fn pod_read_unaligned<T: AnyBitPattern>(bytes: &[u8]) -> T {
+pub fn pod_read_unaligned<T: CheckedBitPattern>(bytes: &[u8]) -> T {
   match try_pod_read_unaligned(bytes) {
     Ok(t) => t,
     Err(e) => something_went_wrong("pod_read_unaligned", e),


### PR DESCRIPTION
Currently, `checked::pod_read_unaligned` requires `T: AnyBitPattern`. (This was likely just a copy-paste error from when the function was introduced in #91.)
There should be no current UB nor semver breakage, since this only relaxes the bound (any type this previously worked with was already sound and will continue to work, due to the blanket `impl<T: AnyBitPattern> CheckedBitPattern for T {}`).
`checked::try_pod_read_unaligned` has the correct `T: CheckedBitPattern` bound.