### PR TITLE
Implement `AnyBitPattern` for `MaybeUninit<T>`

### DIFF
--- a/src/anybitpattern.rs
+++ b/src/anybitpattern.rs
@@ -54,3 +54,9 @@ pub unsafe trait AnyBitPattern:
 }
 
 unsafe impl<T: Pod> AnyBitPattern for T {}
+
+#[cfg(feature = "zeroable_maybe_uninit")]
+unsafe impl<T> AnyBitPattern for core::mem::MaybeUninit<T> where
+  core::mem::MaybeUninit<T>: Copy + 'static
+{
+}


### PR DESCRIPTION
... `where MaybeUninit<T>: Copy + 'static`.

Resolves #108 .

A feature flag is required because `MaybeUninit` was unstable in bytemuck's MSRV. I just used the `#[cfg(feature = "zeroable_maybe_uninit")]` flag since that's required anyway, and it didn't seem reasonable to add another feature flag for this.

The `where MaybeUninit<T>: Copy + 'static` bound is required because of `AnyBitPattern`'s supertrait bounds `Copy + 'static`. A simpler bound would be `where T: Copy + 'static` (i.e. have the bound on `T` instead of `MaybeUninit<T>`). These are currently (and probably always will be) equivalent, but if `std` ever relaxes the `Copy` impl of `MaybeUninit`, this bound will reflect that, whereas `where T: Copy + 'static` would not.