### PR TITLE
Experimental support for `stdsimd` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ unsound_ptr_pod_impl = []
 
 # NOT SEMVER SUPPORTED! TEMPORARY ONLY!
 nightly_portable_simd = []
+nightly_stdsimd = []
 
 [dependencies]
 bytemuck_derive = { version = "1.2.1", path = "derive", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::match_like_matches_macro)]
 #![cfg_attr(feature = "nightly_portable_simd", feature(portable_simd))]
+#![cfg_attr(feature = "nightly_stdsimd", feature(stdsimd))]
 
 //! This crate gives small utilities for casting between plain data types.
 //!

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -321,3 +321,29 @@ where
   core::simd::LaneCount<N>: core::simd::SupportedLaneCount,
 {
 }
+
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86::__m128bh {}
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86::__m256bh {}
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86::__m512 {}
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86::__m512bh {}
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86::__m512d {}
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86::__m512i {}
+
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86_64::__m128bh {}
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86_64::__m256bh {}
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86_64::__m512 {}
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86_64::__m512bh {}
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86_64::__m512d {}
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Pod for x86_64::__m512i {}

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -354,3 +354,29 @@ where
   core::simd::LaneCount<N>: core::simd::SupportedLaneCount,
 {
 }
+
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86::__m128bh {}
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86::__m256bh {}
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86::__m512 {}
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86::__m512bh {}
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86::__m512d {}
+#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86::__m512i {}
+
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86_64::__m128bh {}
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86_64::__m256bh {}
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86_64::__m512 {}
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86_64::__m512bh {}
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86_64::__m512d {}
+#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+unsafe impl Zeroable for x86_64::__m512i {}


### PR DESCRIPTION
Adds experimental support for the `stdsimd` language extension under the `nightly_stdsimd` cargo feature. Closes #121.