### PR TITLE
Implement AnyBitPattern for MaybeUninit<T> where T: AnyBitPattern.

### DIFF
--- a/src/anybitpattern.rs
+++ b/src/anybitpattern.rs
@@ -54,3 +54,7 @@ pub unsafe trait AnyBitPattern:
 }
 
 unsafe impl<T: Pod> AnyBitPattern for T {}
+
+#[cfg(feature = "zeroable_maybe_uninit")]
+unsafe impl<T> AnyBitPattern for core::mem::MaybeUninit<T> where T: AnyBitPattern
+{}


### PR DESCRIPTION
(Partially) resolves #108 .

A feature flag is required because `MaybeUninit` was unstable in bytemuck's MSRV. I just used the `#[cfg(feature = "zeroable_maybe_uninit")]` flag since that's required anyway, and it didn't seem reasonable to add another feature flag for this.

---

As discussed in #152 , it is probably unsound to have `MaybeUninit<T>` implement `AnyBitPattern` when `T` contains interior mutability, so a blanket `impl<T: Copy + 'static> AnyBitPattern for MaybeUninit<T>` would be unsound under that reasoning. However, if `T` implements `AnyBitPattern`, then it is known to not have any interior mutability, so `T: AnyBitPattern` is a sufficient (but not necessary) condition for `MaybeUninit<T>: AnyBitPattern` to be sound.

Since `T: AnyBitPattern`  sufficient-but-not-necessary requirement, it could be relaxed later, e.g. if APIs around `Freeze` become available.