### PR TITLE
various small fixes to the derive macros

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -334,7 +334,7 @@ fn derive_marker_trait_inner<Trait: Derivable>(
   let (trait_impl_extras, trait_impl) = Trait::trait_impl(&input)?;
 
   let implies_trait = if let Some(implies_trait) = Trait::implies_trait() {
-    quote!(unsafe impl #implies_trait for #name {})
+    quote!(unsafe impl #impl_generics #implies_trait for #name #ty_generics #where_clause {})
   } else {
     quote!()
   };

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -432,7 +432,7 @@ fn generate_checked_bit_pattern_struct(
         #[inline]
         #[allow(clippy::double_comparisons)]
         fn is_valid_bit_pattern(bits: &#bits_ty) -> bool {
-            #(<#field_ty as ::bytemuck::CheckedBitPattern>::is_valid_bit_pattern(&bits.#field_name) && )* true
+            #(<#field_ty as ::bytemuck::CheckedBitPattern>::is_valid_bit_pattern(&{ bits.#field_name }) && )* true
         }
     },
   ))

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -609,6 +609,8 @@ mk_repr! {
   I64 => i64,
   I128 => i128,
   U128 => u128,
+  Usize => usize,
+  Isize => isize,
 }
 // where
 macro_rules! mk_repr {(

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -707,7 +707,10 @@ macro_rules! mk_repr {(
           Repr::$Xn => Some(quote!($xn)),
         )*
       };
-      let packed = self.packed.map(|p| quote!(packed(#p)));
+      let packed = self.packed.map(|p| {
+        let lit = LitInt::new(&p.to_string(), Span::call_site());
+        quote!(packed(#lit))
+      });
       let comma = if packed.is_some() && repr.is_some() {
         Some(quote!(,))
       } else {


### PR DESCRIPTION
This pr contributes a few small fixes for the derive macros:
- parse and emit `repr(usize)` and `repr(isize)` on enums
- fix how the value in the `packed` attribute is emitted
- fix deriving `CheckedBitPattern` on packed structs by avoiding creating references to the fields
- fix the implementation of derived traits by emitting generics