### PR TITLE
allow deriving `CheckedBitPattern` for enums with fields

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -237,16 +237,17 @@ pub fn derive_no_uninit(
 /// for the `CheckedBitPattern` trait and derives the required `Bits` type
 /// definition and `is_valid_bit_pattern` method for the type automatically.
 ///
-/// The following constraints need to be satisfied for the macro to succeed
-/// (the rest of the constraints are guaranteed by the `CheckedBitPattern`
-/// subtrait bounds, i.e. are guaranteed by the requirements of the `NoUninit`
-/// trait which `CheckedBitPattern` is a subtrait of):
+/// The following constraints need to be satisfied for the macro to succeed:
 ///
 /// If applied to a struct:
 /// - All fields must implement `CheckedBitPattern`
+/// - The struct must be `#[repr(C)]` or `#[repr(transparent)]`
+/// - The struct must contain no generic parameters
 ///
 /// If applied to an enum:
-/// - All requirements already checked by `NoUninit`, just impls the trait
+/// - The enum must be explicit `#[repr(Int)]`
+/// - All fields in variants must implement `CheckedBitPattern`
+/// - The enum must contain no generic parameters
 #[proc_macro_derive(CheckedBitPattern)]
 pub fn derive_maybe_pod(
   input: proc_macro::TokenStream,

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -218,7 +218,7 @@ pub fn derive_zeroable(
 /// - The struct must contain no generic parameters
 ///
 /// If applied to an enum:
-/// - The enum must be explicit `#[repr(Int)]`
+/// - The enum must be explicit `#[repr(Int)]`, `#[repr(C)]`, or both
 /// - All variants must be fieldless
 /// - The enum must contain no generic parameters
 #[proc_macro_derive(NoUninit)]

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -762,6 +762,11 @@ macro_rules! mk_repr {(
         meta.push(quote!(packed(#lit)));
       }
 
+      if let Some(align) = self.align.as_ref() {
+        let lit = LitInt::new(&align.to_string(), Span::call_site());
+        meta.push(quote!(align(#lit)));
+      }
+
       tokens.extend(quote!(
         #[repr(#meta)]
       ));

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -739,7 +739,7 @@ macro_rules! mk_repr {(
           _ => return Err(input.error("unrecognized representation hint"))
         };
         if ::core::mem::replace(&mut ret.repr, new_repr) != Repr::Rust {
-          input.error("duplicate representation hint");
+          return Err(input.error("duplicate representation hint"));
         }
         let _: Option<Token![,]> = input.parse()?;
       }

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -214,7 +214,7 @@ impl Derivable for CheckedBitPattern {
             bail!("CheckedBitPattern requires the enum to be an explicit #[repr(Int)]")
           }
         } else if matches!(repr.repr, Repr::Rust) {
-          bail!("the default Rust repr doesn't have a specified type layout")
+          bail!("CheckedBitPattern requires an explicit repr annotation because `repr(Rust)` doesn't have a specified type layout")
         } else {
           Ok(())
         }

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -160,6 +160,29 @@ struct AnyBitPatternTest<A: AnyBitPattern, B: AnyBitPattern> {
   b: B,
 }
 
+#[derive(Clone, Copy, CheckedBitPattern)]
+#[repr(C, align(8))]
+struct CheckedBitPatternAlignedStruct {
+  a: u16,
+}
+
+/// ```compile_fail
+/// use bytemuck::{Pod, Zeroable};
+///
+/// #[derive(Pod, Zeroable)]
+/// #[repr(transparent)]
+/// struct TransparentSingle<T>(T);
+///
+/// struct NotPod(u32);
+///
+/// let _: u32 = bytemuck::cast(TransparentSingle(NotPod(0u32)));
+/// ```
+#[derive(
+  Debug, Copy, Clone, PartialEq, Eq, Pod, Zeroable, TransparentWrapper,
+)]
+#[repr(transparent)]
+struct NewtypeWrapperTest<T>(T);
+
 #[test]
 fn fails_cast_contiguous() {
   let can_cast = CheckedBitPatternEnumWithValues::is_valid_bit_pattern(&5);
@@ -244,6 +267,12 @@ fn checkedbitpattern_try_pod_read_unaligned() {
     CheckedBitPatternEnumWithValues,
   >(&pod);
   assert!(res.is_err());
+}
+
+#[test]
+fn checkedbitpattern_aligned_struct() {
+  let pod = [0u8; 8];
+  bytemuck::checked::pod_read_unaligned::<CheckedBitPatternAlignedStruct>(&pod);
 }
 
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -374,8 +374,6 @@ fn checkedbitpattern_int_enum_with_fields() {
 #[test]
 fn checkedbitpattern_nested_enum_with_fields() {
   // total size 24 bytes. first byte always the u8 discriminant.
-  // with variant A, nested CheckedBitPatternCEnumWithFields begins at byte 4.
-  // with variant B, nested CheckedBitPatternCDefaultDiscriminantEnumWithFields begins at byte 8.
 
   #[repr(C, align(8))]
   struct Align8Bytes([u8; 24]);


### PR DESCRIPTION
This pr consist of two parts:
1. Miscellaneous improvements to the internal `Representation` type
2. The implementation for deriving `CheckedBitPattern` for enums with fields

The following representations have a stable type layout for enums with fields and are now supported in the `CheckedBitPattern` derive macro:
- `#[repr(C)]`
- `#[repr(C, int)]`
- `#[repr(int)]`
- `#[repr(transparent)]`

The representations are specified at https://doc.rust-lang.org/reference/type-layout.html.

Closes #166