### PR TITLE
Fix soundness issue of TransparentWrapper derive macro.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Cargo.lock
 **/*.rs.bk
 
 /derive/target/
+/derive/.vscode/

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -64,7 +64,7 @@ unsafe impl<T> Zeroable for *const [T] {}
 unsafe impl Zeroable for *mut str {}
 unsafe impl Zeroable for *const str {}
 
-unsafe impl<T: Zeroable> Zeroable for PhantomData<T> {}
+unsafe impl<T: ?Sized> Zeroable for PhantomData<T> {}
 unsafe impl Zeroable for PhantomPinned {}
 unsafe impl<T: Zeroable> Zeroable for ManuallyDrop<T> {}
 unsafe impl<T: Zeroable> Zeroable for core::cell::UnsafeCell<T> {}


### PR DESCRIPTION
May resolve #170.

 Uses the compiler to check that all non-wrapped fields are actually 1-ZSTs, and uses Zeroable to check that all non-wrapped fields are "conjurable" (See [discussion](https://github.com/Lokathor/bytemuck/issues/170#issuecomment-1431922210) in the linked issue).

Additionally, relaxes the bound of `impl<T: Zeroable> Zeroable for PhantomData<T>` to all `T: ?Sized`.