### PR TITLE
Switch to `syn` 2.0

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 
 [dependencies]
 # syn seems to have broken backwards compatibility in this version https://github.com/dtolnay/syn/issues/1194
-syn = "1.0.99"
+syn = "2.0.1"
 quote = "1"
 proc-macro2 = "1"
 

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -573,13 +573,11 @@ fn get_ident_from_stream(tokens: TokenStream) -> Option<Ident> {
 /// get a simple #[foo(bar)] attribute, returning "bar"
 fn get_simple_attr(attributes: &[Attribute], attr_name: &str) -> Option<Ident> {
   for attr in attributes {
-    if let (AttrStyle::Outer, Some(outer_ident), Some(inner_ident)) = (
-      &attr.style,
-      attr.path.get_ident(),
-      get_ident_from_stream(attr.tokens.clone()),
-    ) {
-      if outer_ident.to_string() == attr_name {
-        return Some(inner_ident);
+    if let (AttrStyle::Outer, Meta::List(list)) = (&attr.style, &attr.meta) {
+      if list.path.is_ident(attr_name) {
+        if let Some(ident) = get_ident_from_stream(list.tokens.clone()) {
+          return Some(ident);
+        }
       }
     }
   }
@@ -591,7 +589,7 @@ fn get_repr(attributes: &[Attribute]) -> Result<Representation> {
   attributes
     .iter()
     .filter_map(|attr| {
-      if attr.path.is_ident("repr") {
+      if attr.path().is_ident("repr") {
         Some(attr.parse_args::<Representation>())
       } else {
         None


### PR DESCRIPTION
This upgrades the derives from `syn` 1.0 to `syn` 2.0. While the MSRV for `syn` 2.0 is not Rust 1.56 which is higher than the MSRV of `bytemuck`, the derives don't fall under the MSRV policy.