### PR TITLE
Add functions for writing zeroed bytes to `&mut impl Zeroable` and `&mut [impl Zeroable]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,3 +398,33 @@ pub fn try_cast_slice_mut<
 ) -> Result<&mut [B], PodCastError> {
   unsafe { internal::try_cast_slice_mut(a) }
 }
+
+/// Fill all bytes of `target` with zeroes (see [`Zeroable`]).
+///
+/// This is similar to `*target = Zeroable::zeroed()`, but guarantees that any
+/// padding bytes in `target` are zeroed as well.
+///
+/// See also [`fill_zero`], if you have a slice rather than a single value.
+#[inline]
+pub fn write_zero<T: Zeroable + Copy>(target: &mut T) {
+  unsafe {
+    core::ptr::write_bytes(
+      target as *mut T as *mut u8,
+      0u8,
+      core::mem::size_of::<T>(),
+    )
+  }
+}
+
+/// Fill all bytes of `slice` with zeroes (see [`Zeroable`]).
+///
+/// This is similar to `slice.fill(Zeroable::zeroed())`, but guarantees that any
+/// padding bytes in `slice` are zeroed as well.
+///
+/// See also [`write_zero`], which zeroes all bytes of a single value rather
+/// than a slice.
+#[inline]
+pub fn fill_zero<T: Zeroable + Copy>(slice: &mut [T]) {
+  let len = core::mem::size_of_val::<[T]>(slice);
+  unsafe { core::ptr::write_bytes(slice.as_mut_ptr() as *mut u8, 0u8, len) }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,11 +412,7 @@ pub fn write_zero<T: Zeroable>(target: &mut T) {
     #[inline(always)]
     fn drop(&mut self) {
       unsafe {
-        core::ptr::write_bytes(
-          self.0.cast::<u8>(),
-          0u8,
-          core::mem::size_of::<T>(),
-        );
+        core::ptr::write_bytes(self.0, 0u8, 1);
       }
     }
   }


### PR DESCRIPTION
Two reasons this functionality is worth having:

1. Some cases in FFI want a struct required input to be cleared with `memset`, because they expect to add fields to the end of a struct and use `sizeof(TheStruct)` to indicate which fields exist on the type.

	That is: a new field could be added to the end of a struct without changing the size if the bytes of that field were previously tail padding -- in this case if all bytes were not zeroed in this manner, the uninit bytes in the field may be interpreted as having meaning.

2. `*blah = T::zeroed()` will end up having a few redundant copies of `T` on the stack in debug builds which could cause various problems.

I didn't add these as methods on `Zeroable` intentionally, but don't care much about it. If you'd prefer them there or something else I'm fine with it.

I'm pretty sure I didn't miss anything in terms of correctness here, although I had initially forgotten that `Zeroable` didn't imply `Copy`, so a bit of scrutiny wouldn't be out of place to ensure I'm not adding a problematic API.