### PR TITLE
must_cast: fix test failures and fmt.

### DIFF
--- a/src/must.rs
+++ b/src/must.rs
@@ -81,8 +81,7 @@ pub fn must_cast_ref<A: NoUninit, B: AnyBitPattern>(a: &A) -> &B {
 /// let bytes: &mut [u8; 2] = bytemuck::must_cast_mut(&mut i);
 /// ```
 /// ```compile_fail,E0080
-/// # let mut bytes : [u8; 2] = [1, 2];
-/// # let bytes = &mut bytes[..];
+/// # let mut bytes: &mut [u8; 2] = &mut [1, 2];
 /// // fails to compile (alignment requirements increased):
 /// let i : &mut u16 = bytemuck::must_cast_mut(bytes);
 /// ```
@@ -124,7 +123,7 @@ pub fn must_cast_mut<
 /// let bytes: &[u8] = bytemuck::must_cast_slice(indicies);
 /// ```
 /// ```compile_fail,E0080
-/// # let bytes : &[u8] = [1, 0, 2, 0, 3, 0];
+/// # let bytes : &[u8] = &[1, 0, 2, 0, 3, 0];
 /// // fails to compile (bytes.len() might not be a multiple of 2):
 /// let byte_pairs : &[[u8; 2]] = bytemuck::must_cast_slice(bytes);
 /// ```

--- a/src/must.rs
+++ b/src/must.rs
@@ -17,7 +17,10 @@ impl<A, B> Cast<A, B> {
   );
 }
 
-// Workaround for https://github.com/rust-lang/miri/issues/2423
+// Workaround for https://github.com/rust-lang/miri/issues/2423.
+// Miri currently doesn't see post-monomorphization errors until runtime,
+// so `compile_fail` tests relying on post-monomorphization errors don't
+// actually fail. Instead use `should_panic` under miri as a workaround.
 #[cfg(miri)]
 macro_rules! post_mono_compile_fail_doctest {
   () => {

--- a/src/must.rs
+++ b/src/must.rs
@@ -17,6 +17,20 @@ impl<A, B> Cast<A, B> {
   );
 }
 
+// Workaround for https://github.com/rust-lang/miri/issues/2423
+#[cfg(miri)]
+macro_rules! post_mono_compile_fail_doctest {
+  () => {
+    "```should_panic"
+  };
+}
+#[cfg(not(miri))]
+macro_rules! post_mono_compile_fail_doctest {
+  () => {
+    "```compile_fail,E0080"
+  };
+}
+
 /// Cast `A` into `B` if infalliable, or fail to compile.
 ///
 /// Note that for this particular type of cast, alignment isn't a factor. The
@@ -33,7 +47,7 @@ impl<A, B> Cast<A, B> {
 /// // compiles:
 /// let bytes: [u8; 2] = bytemuck::must_cast(12_u16);
 /// ```
-/// ```compile_fail,E0080
+#[doc = post_mono_compile_fail_doctest!()]
 /// // fails to compile (size mismatch):
 /// let bytes : [u8; 3] = bytemuck::must_cast(12_u16);
 /// ```
@@ -55,11 +69,11 @@ pub fn must_cast<A: NoUninit, B: AnyBitPattern>(a: A) -> B {
 /// // compiles:
 /// let bytes: &[u8; 2] = bytemuck::must_cast_ref(&12_u16);
 /// ```
-/// ```compile_fail,E0080
+#[doc = post_mono_compile_fail_doctest!()]
 /// // fails to compile (size mismatch):
 /// let bytes : &[u8; 3] = bytemuck::must_cast_ref(&12_u16);
 /// ```
-/// ```compile_fail,E0080
+#[doc = post_mono_compile_fail_doctest!()]
 /// // fails to compile (alignment requirements increased):
 /// let bytes : &u16 = bytemuck::must_cast_ref(&[1u8, 2u8]);
 /// ```
@@ -80,12 +94,12 @@ pub fn must_cast_ref<A: NoUninit, B: AnyBitPattern>(a: &A) -> &B {
 /// // compiles:
 /// let bytes: &mut [u8; 2] = bytemuck::must_cast_mut(&mut i);
 /// ```
-/// ```compile_fail,E0080
+#[doc = post_mono_compile_fail_doctest!()]
 /// # let mut bytes: &mut [u8; 2] = &mut [1, 2];
 /// // fails to compile (alignment requirements increased):
 /// let i : &mut u16 = bytemuck::must_cast_mut(bytes);
 /// ```
-/// ```compile_fail,E0080
+#[doc = post_mono_compile_fail_doctest!()]
 /// # let mut i = 12_u16;
 /// // fails to compile (size mismatch):
 /// let bytes : &mut [u8; 3] = bytemuck::must_cast_mut(&mut i);
@@ -122,12 +136,12 @@ pub fn must_cast_mut<
 /// // compiles:
 /// let bytes: &[u8] = bytemuck::must_cast_slice(indicies);
 /// ```
-/// ```compile_fail,E0080
+#[doc = post_mono_compile_fail_doctest!()]
 /// # let bytes : &[u8] = &[1, 0, 2, 0, 3, 0];
 /// // fails to compile (bytes.len() might not be a multiple of 2):
 /// let byte_pairs : &[[u8; 2]] = bytemuck::must_cast_slice(bytes);
 /// ```
-/// ```compile_fail,E0080
+#[doc = post_mono_compile_fail_doctest!()]
 /// # let byte_pairs : &[[u8; 2]] = &[[1, 0], [2, 0], [3, 0]];
 /// // fails to compile (alignment requirements increased):
 /// let indicies : &[u16] = bytemuck::must_cast_slice(byte_pairs);
@@ -156,13 +170,13 @@ pub fn must_cast_slice<A: NoUninit, B: AnyBitPattern>(a: &[A]) -> &[B] {
 /// // compiles:
 /// let bytes: &mut [u8] = bytemuck::must_cast_slice_mut(indicies);
 /// ```
-/// ```compile_fail,E0080
+#[doc = post_mono_compile_fail_doctest!()]
 /// # let mut bytes = [1, 0, 2, 0, 3, 0];
 /// # let bytes : &mut [u8] = &mut bytes[..];
 /// // fails to compile (bytes.len() might not be a multiple of 2):
 /// let byte_pairs : &mut [[u8; 2]] = bytemuck::must_cast_slice_mut(bytes);
 /// ```
-/// ```compile_fail,E0080
+#[doc = post_mono_compile_fail_doctest!()]
 /// # let mut byte_pairs = [[1, 0], [2, 0], [3, 0]];
 /// # let byte_pairs : &mut [[u8; 2]] = &mut byte_pairs[..];
 /// // fails to compile (alignment requirements increased):

--- a/src/must.rs
+++ b/src/must.rs
@@ -8,9 +8,13 @@ use core::mem::{align_of, size_of};
 
 struct Cast<A, B>((A, B));
 impl<A, B> Cast<A, B> {
-  const ASSERT_ALIGN_GREATER_THAN_EQUAL : () = assert!(align_of::<A>() >= align_of::<B>());
-  const ASSERT_SIZE_EQUAL : () = assert!(size_of::<A>() == size_of::<B>());
-  const ASSERT_SIZE_MULTIPLE_OF : () = assert!((size_of::<A>() == 0) == (size_of::<B>() == 0) && (size_of::<A>() % size_of::<B>() == 0));
+  const ASSERT_ALIGN_GREATER_THAN_EQUAL: () =
+    assert!(align_of::<A>() >= align_of::<B>());
+  const ASSERT_SIZE_EQUAL: () = assert!(size_of::<A>() == size_of::<B>());
+  const ASSERT_SIZE_MULTIPLE_OF: () = assert!(
+    (size_of::<A>() == 0) == (size_of::<B>() == 0)
+      && (size_of::<A>() % size_of::<B>() == 0)
+  );
 }
 
 /// Cast `A` into `B` if infalliable, or fail to compile.
@@ -27,7 +31,7 @@ impl<A, B> Cast<A, B> {
 /// ## Examples
 /// ```
 /// // compiles:
-/// let bytes : [u8; 2] = bytemuck::must_cast(12_u16);
+/// let bytes: [u8; 2] = bytemuck::must_cast(12_u16);
 /// ```
 /// ```compile_fail,E0080
 /// // fails to compile (size mismatch):
@@ -49,7 +53,7 @@ pub fn must_cast<A: NoUninit, B: AnyBitPattern>(a: A) -> B {
 /// ## Examples
 /// ```
 /// // compiles:
-/// let bytes : &[u8; 2] = bytemuck::must_cast_ref(&12_u16);
+/// let bytes: &[u8; 2] = bytemuck::must_cast_ref(&12_u16);
 /// ```
 /// ```compile_fail,E0080
 /// // fails to compile (size mismatch):
@@ -74,7 +78,7 @@ pub fn must_cast_ref<A: NoUninit, B: AnyBitPattern>(a: &A) -> &B {
 /// ```
 /// let mut i = 12_u16;
 /// // compiles:
-/// let bytes : &mut [u8; 2] = bytemuck::must_cast_mut(&mut i);
+/// let bytes: &mut [u8; 2] = bytemuck::must_cast_mut(&mut i);
 /// ```
 /// ```compile_fail,E0080
 /// # let mut bytes : [u8; 2] = [1, 2];
@@ -99,7 +103,8 @@ pub fn must_cast_mut<
   unsafe { &mut *(a as *mut A as *mut B) }
 }
 
-/// Convert `&[A]` into `&[B]` (possibly with a change in length) if infalliable, or fail to compile.
+/// Convert `&[A]` into `&[B]` (possibly with a change in length) if
+/// infalliable, or fail to compile.
 ///
 /// * `input.as_ptr() as usize == output.as_ptr() as usize`
 /// * `input.len() * size_of::<A>() == output.len() * size_of::<B>()`
@@ -107,16 +112,16 @@ pub fn must_cast_mut<
 /// ## Failure
 ///
 /// * If the target type has a greater alignment requirement.
-/// * If the target element type doesn't evenly fit into the the current element type
-///   (eg: 3 `u16` values is 1.5 `u32` values, so that's a failure).
+/// * If the target element type doesn't evenly fit into the the current element
+///   type (eg: 3 `u16` values is 1.5 `u32` values, so that's a failure).
 /// * Similarly, you can't convert between a [ZST](https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts)
 ///   and a non-ZST.
 ///
 /// ## Examples
 /// ```
-/// let indicies : &[u16] = &[1, 2, 3];
+/// let indicies: &[u16] = &[1, 2, 3];
 /// // compiles:
-/// let bytes : &[u8] = bytemuck::must_cast_slice(indicies);
+/// let bytes: &[u8] = bytemuck::must_cast_slice(indicies);
 /// ```
 /// ```compile_fail,E0080
 /// # let bytes : &[u8] = [1, 0, 2, 0, 3, 0];
@@ -140,16 +145,17 @@ pub fn must_cast_slice<A: NoUninit, B: AnyBitPattern>(a: &[A]) -> &[B] {
   unsafe { core::slice::from_raw_parts(a.as_ptr() as *const B, new_len) }
 }
 
-/// Convert `&mut [A]` into `&mut [B]` (possibly with a change in length) if infalliable, or fail to compile.
+/// Convert `&mut [A]` into `&mut [B]` (possibly with a change in length) if
+/// infalliable, or fail to compile.
 ///
 /// As [`must_cast_slice`], but `&mut`.
 ///
 /// ## Examples
 /// ```
 /// let mut indicies = [1, 2, 3];
-/// let indicies : &mut [u16] = &mut indicies;
+/// let indicies: &mut [u16] = &mut indicies;
 /// // compiles:
-/// let bytes : &mut [u8] = bytemuck::must_cast_slice_mut(indicies);
+/// let bytes: &mut [u8] = bytemuck::must_cast_slice_mut(indicies);
 /// ```
 /// ```compile_fail,E0080
 /// # let mut bytes = [1, 0, 2, 0, 3, 0];


### PR DESCRIPTION
All doctests in `src/main.rs` were failing under miri due to https://github.com/rust-lang/miri/issues/2423. As a temporary workaround, instead mark those tests as `should_panic` under miri, and `compile_fail` only under not(miri) (b275f7dc76123854765e116e5085e65cdc43e69e).

Two doctests in `src/must.rs` were failing for unrelated reasons (4809de5b1294cb0106c6bbf7e09b5184803ea2de).

(Also `cargo fmt` on `src/must.rs`)