### PR TITLE
Zeroable derive custom bounds

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -6,10 +6,7 @@ mod traits;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{
-  parse_macro_input, punctuated::Punctuated, DeriveInput, MetaNameValue,
-  Result, WherePredicate,
-};
+use syn::{parse_macro_input, DeriveInput, Result};
 
 use crate::traits::{
   AnyBitPattern, CheckedBitPattern, Contiguous, Derivable, NoUninit, Pod,
@@ -382,7 +379,7 @@ fn find_and_parse_helper_attributes<P: syn::parse::Parser + Copy>(
     // e.g. `#[zeroable]`
     syn::Meta::Path(path) => path
       .is_ident(name)
-      .then(|| Err(syn::Error::new_spanned(&path, &invalid_format_msg))),
+      .then(|| Err(syn::Error::new_spanned(path, &invalid_format_msg))),
     // If a `NameValue` matches our `name`, return an error, else ignore it.
     // e.g. `#[zeroable = "hello"]`
     syn::Meta::NameValue(namevalue) => {
@@ -394,8 +391,8 @@ fn find_and_parse_helper_attributes<P: syn::parse::Parser + Copy>(
     // ignore it. If its contents match our format, return the value, else
     // return an error.
     syn::Meta::List(list) => list.path.is_ident(name).then(|| {
-      let namevalue: MetaNameValue =
-        syn::parse2(list.tokens.clone()).map_err(|_| {
+      let namevalue: syn::MetaNameValue = syn::parse2(list.tokens.clone())
+        .map_err(|_| {
           syn::Error::new_spanned(&list.tokens, &invalid_format_msg)
         })?;
       if namevalue.path.is_ident(key) {
@@ -418,7 +415,7 @@ fn find_and_parse_helper_attributes<P: syn::parse::Parser + Copy>(
     .map(|lit| {
       let lit = lit?;
       lit.parse_with(parser).map_err(|err| {
-        syn::Error::new_spanned(&lit, &format!("{invalid_value_msg}: {err}"))
+        syn::Error::new_spanned(&lit, format!("{invalid_value_msg}: {err}"))
       })
     })
     .collect()
@@ -435,7 +432,7 @@ fn derive_marker_trait_inner<Trait: Derivable>(
       &input.attrs,
       name,
       "bound",
-      <Punctuated<WherePredicate, syn::Token![,]>>::parse_terminated,
+      <syn::punctuated::Punctuated<syn::WherePredicate, syn::Token![,]>>::parse_terminated,
       "Type: Trait",
       "invalid where predicate",
     )?;

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -35,6 +35,9 @@ pub trait Derivable {
   fn requires_where_clause() -> bool {
     true
   }
+  fn explicit_bounds_attribute_name() -> Option<&'static str> {
+    None
+  }
 }
 
 pub struct Pod;
@@ -125,6 +128,10 @@ impl Derivable for Zeroable {
       Data::Struct(_) => generate_fields_are_trait(input, Self::ident(input)?),
       Data::Enum(_) => bail!("Deriving Zeroable is not supported for enums"),
     }
+  }
+
+  fn explicit_bounds_attribute_name() -> Option<&'static str> {
+    Some("zeroable")
   }
 }
 

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -532,7 +532,7 @@ fn generate_assert_no_padding(input: &DeriveInput) -> Result<TokenStream> {
     let size_rest =
       quote_spanned!(span => #( + ::core::mem::size_of::<#field_types>() )*);
 
-    quote_spanned!(span => #size_first#size_rest)
+    quote_spanned!(span => #size_first #size_rest)
   } else {
     quote_spanned!(span => 0)
   };


### PR DESCRIPTION
Adds the ability to use custom bounds when using `derive(Zeroable)` *instead of* the normal "add a bound to each of the generics".

The normal soundness checks are still performed, so the custom bound must guarantee that the struct is actually zeroable, or compilation will fail.

Unresolved questions:

* Should bounds for each field implicitly be added (as described in https://github.com/Lokathor/bytemuck/issues/190#issuecomment-1563796078)? i.e. ["Perfect Derive"](https://smallcultfollowing.com/babysteps//blog/2022/04/12/implied-bounds-and-perfect-derive/#what-is-perfect-derive). This wouldn't be hard, and might make the whole "give explicit bounds" part of this PR obsolete (since the "bound on the fields" can be done without additional information), except as to *restrict* the impl.

<details>
<summary>Emit bounds for each field</summary>
If

```rs
#[derive(Zeroable)]
struct Struct<T, U, V> {
  a: Cell<usize>,
  b: PhantomData<T>,
  c: Option<Box<U>>,
  d: [V; 3],
}
```

emitted

```rs
unsafe impl<T, U, V> Zeroable for Struct<T, U, V>
  where
    Cell<usize>: Zeroable,
    PhantomData<T>: Zeroable,
    Option<Box<U>>: Zeroable,
    [V; 3]: Zeroable,
 {}
 ```
 
 that would work and not require the user to give any bounds.

</details>

Possible future work:
* Something similar for other traits (e.g. `Pod` for #191. I was looking at it, and it's harder than just re-using this PR's code because of the additional requirements of `Pod`.)