### PR TITLE
Update proc-macro2

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 # syn seems to have broken backwards compatibility in this version https://github.com/dtolnay/syn/issues/1194
 syn = "2.0.1"
 quote = "1"
-proc-macro2 = "1"
+proc-macro2 = "1.0.60"
 
 [dev-dependencies]
 bytemuck = { path = "../", features = ["derive"] }


### PR DESCRIPTION
This sets the version of proc-macro2 used by `bytemuck_derive` to `1.0.60`, which prevents it from attempting to use the `proc_macro_span_shrink` feature on the nightly compiler that no longer exists.