### PR TITLE
Fix derive non-run doctests and expand docs for Pod and TransparentWrapper derives.

### DIFF
--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -160,38 +160,6 @@ struct AnyBitPatternTest<A: AnyBitPattern, B: AnyBitPattern> {
   b: B,
 }
 
-/// ```compile_fail
-/// use bytemuck::{Pod, Zeroable};
-///
-/// #[derive(Pod, Zeroable)]
-/// #[repr(transparent)]
-/// struct TransparentSingle<T>(T);
-///
-/// struct NotPod(u32);
-///
-/// let _: u32 = bytemuck::cast(TransparentSingle(NotPod(0u32)));
-/// ```
-#[derive(
-  Debug, Copy, Clone, PartialEq, Eq, Pod, Zeroable, TransparentWrapper,
-)]
-#[repr(transparent)]
-struct NewtypeWrapperTest<T>(T);
-
-/// ```compile_fail
-/// use bytemuck::TransparentWrapper;
-///
-/// struct NonTransparentSafeZST;
-///
-/// #[derive(TransparentWrapper)]
-/// #[repr(transparent)]
-/// struct Wrapper<T>(T, NonTransparentSafeZST);
-/// ```
-#[derive(
-  Debug, Copy, Clone, PartialEq, Eq, Pod, Zeroable, TransparentWrapper,
-)]
-#[repr(transparent)]
-struct TransarentWrapperZstTest<T>(T);
-
 #[test]
 fn fails_cast_contiguous() {
   let can_cast = CheckedBitPatternEnumWithValues::is_valid_bit_pattern(&5);


### PR DESCRIPTION
Doctests only run in the crate proper; doctests inside of integration tests are not run. Move the doctests from the integration test `derive/tests/basic.rs` to be doctests on their respective derive macro defintions in `derive/lib.rs` so they are actually run, expanding them[^2][^3] to make them better for documentation as well.

Also updated the documentation for the `Pod` and `TransparentWrapper` derive macros to reflect their current state (`derive(Pod)` allows generics if and only if `#[repr(transparent)]`; `derive(TransparentWrapper)` requires any ZST fields be `Zeroable`).

---

[^2]: `NewtypeWrapperTest` was testing that `#[derive(Pod, ...)] #[repr(transparent)] struct Generic<A>(A);` is only `Pod` if `A: Pod`, which is now shown by lines 61-88 on the docs for `Pod`'s derive macro.
[^3]: `TransarentWrapperZstTest` was testing that `#[derive(TransparentWrapper)] struct Wrapper(T, NonZeroableZST);` fails, which is now shown by lines 305-320 on the docs for `TransparentWrapper`'s derive macro.