### PR TITLE
Have `cfg`s as part of the input to `impl_unsafe_marker_for_simd`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,13 @@ macro_rules! transmute {
 /// with relevant cargo features enabled.
 #[allow(unused)]
 macro_rules! impl_unsafe_marker_for_simd {
-  (unsafe impl $trait:ident for $platform:ident :: {}) => {};
-  (unsafe impl $trait:ident for $platform:ident :: { $first_type:ident $(, $types:ident)* $(,)? }) => {
+  ($(#[cfg($cfg_predicate:meta)])? unsafe impl $trait:ident for $platform:ident :: {}) => {};
+  ($(#[cfg($cfg_predicate:meta)])? unsafe impl $trait:ident for $platform:ident :: { $first_type:ident $(, $types:ident)* $(,)? }) => {
+    $( #[cfg($cfg_predicate)] )?
+    $( #[cfg_attr(feature = "nightly_docs", doc(cfg($cfg_predicate)))] )?
     unsafe impl $trait for $platform::$first_type {}
-    impl_unsafe_marker_for_simd!(unsafe impl $trait for $platform::{ $( $types ),* });
+    $( #[cfg($cfg_predicate)] )? // To prevent recursion errors if nothing is going to be expanded anyway.
+    impl_unsafe_marker_for_simd!($( #[cfg($cfg_predicate)] )? unsafe impl $trait for $platform::{ $( $types ),* });
   };
 }
 

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -54,13 +54,22 @@ unsafe impl Pod for f64 {}
 unsafe impl<T: Pod> Pod for Wrapping<T> {}
 
 #[cfg(feature = "unsound_ptr_pod_impl")]
-#[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "unsound_ptr_pod_impl")))]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(feature = "unsound_ptr_pod_impl"))
+)]
 unsafe impl<T: 'static> Pod for *mut T {}
 #[cfg(feature = "unsound_ptr_pod_impl")]
-#[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "unsound_ptr_pod_impl")))]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(feature = "unsound_ptr_pod_impl"))
+)]
 unsafe impl<T: 'static> Pod for *const T {}
 #[cfg(feature = "unsound_ptr_pod_impl")]
-#[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "unsound_ptr_pod_impl")))]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(feature = "unsound_ptr_pod_impl"))
+)]
 unsafe impl<T: 'static> PodInOption for NonNull<T> {}
 
 unsafe impl<T: ?Sized + 'static> Pod for PhantomData<T> {}
@@ -80,55 +89,58 @@ impl_unsafe_marker_for_array!(
   512, 1024, 2048, 4096
 );
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm_simd"))]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Pod for wasm32::{v128}
+  #[cfg(all(target_arch = "wasm32", feature = "wasm_simd"))]
+  unsafe impl Pod for wasm32::{v128}
 );
 
-#[cfg(all(target_arch = "aarch64", feature = "aarch64_simd"))]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Pod for aarch64::{
-        float32x2_t, float32x2x2_t, float32x2x3_t, float32x2x4_t, float32x4_t,
-        float32x4x2_t, float32x4x3_t, float32x4x4_t, float64x1_t, float64x1x2_t,
-        float64x1x3_t, float64x1x4_t, float64x2_t, float64x2x2_t, float64x2x3_t,
-        float64x2x4_t, int16x4_t, int16x4x2_t, int16x4x3_t, int16x4x4_t, int16x8_t,
-        int16x8x2_t, int16x8x3_t, int16x8x4_t, int32x2_t, int32x2x2_t, int32x2x3_t,
-        int32x2x4_t, int32x4_t, int32x4x2_t, int32x4x3_t, int32x4x4_t, int64x1_t,
-        int64x1x2_t, int64x1x3_t, int64x1x4_t, int64x2_t, int64x2x2_t, int64x2x3_t,
-        int64x2x4_t, int8x16_t, int8x16x2_t, int8x16x3_t, int8x16x4_t, int8x8_t,
-        int8x8x2_t, int8x8x3_t, int8x8x4_t, poly16x4_t, poly16x4x2_t, poly16x4x3_t,
-        poly16x4x4_t, poly16x8_t, poly16x8x2_t, poly16x8x3_t, poly16x8x4_t,
-        poly64x1_t, poly64x1x2_t, poly64x1x3_t, poly64x1x4_t, poly64x2_t,
-        poly64x2x2_t, poly64x2x3_t, poly64x2x4_t, poly8x16_t, poly8x16x2_t,
-        poly8x16x3_t, poly8x16x4_t, poly8x8_t, poly8x8x2_t, poly8x8x3_t, poly8x8x4_t,
-        uint16x4_t, uint16x4x2_t, uint16x4x3_t, uint16x4x4_t, uint16x8_t,
-        uint16x8x2_t, uint16x8x3_t, uint16x8x4_t, uint32x2_t, uint32x2x2_t,
-        uint32x2x3_t, uint32x2x4_t, uint32x4_t, uint32x4x2_t, uint32x4x3_t,
-        uint32x4x4_t, uint64x1_t, uint64x1x2_t, uint64x1x3_t, uint64x1x4_t,
-        uint64x2_t, uint64x2x2_t, uint64x2x3_t, uint64x2x4_t, uint8x16_t,
-        uint8x16x2_t, uint8x16x3_t, uint8x16x4_t, uint8x8_t, uint8x8x2_t,
-        uint8x8x3_t, uint8x8x4_t,
-      }
+  #[cfg(all(target_arch = "aarch64", feature = "aarch64_simd"))]
+  unsafe impl Pod for aarch64::{
+    float32x2_t, float32x2x2_t, float32x2x3_t, float32x2x4_t, float32x4_t,
+    float32x4x2_t, float32x4x3_t, float32x4x4_t, float64x1_t, float64x1x2_t,
+    float64x1x3_t, float64x1x4_t, float64x2_t, float64x2x2_t, float64x2x3_t,
+    float64x2x4_t, int16x4_t, int16x4x2_t, int16x4x3_t, int16x4x4_t, int16x8_t,
+    int16x8x2_t, int16x8x3_t, int16x8x4_t, int32x2_t, int32x2x2_t, int32x2x3_t,
+    int32x2x4_t, int32x4_t, int32x4x2_t, int32x4x3_t, int32x4x4_t, int64x1_t,
+    int64x1x2_t, int64x1x3_t, int64x1x4_t, int64x2_t, int64x2x2_t, int64x2x3_t,
+    int64x2x4_t, int8x16_t, int8x16x2_t, int8x16x3_t, int8x16x4_t, int8x8_t,
+    int8x8x2_t, int8x8x3_t, int8x8x4_t, poly16x4_t, poly16x4x2_t, poly16x4x3_t,
+    poly16x4x4_t, poly16x8_t, poly16x8x2_t, poly16x8x3_t, poly16x8x4_t,
+    poly64x1_t, poly64x1x2_t, poly64x1x3_t, poly64x1x4_t, poly64x2_t,
+    poly64x2x2_t, poly64x2x3_t, poly64x2x4_t, poly8x16_t, poly8x16x2_t,
+    poly8x16x3_t, poly8x16x4_t, poly8x8_t, poly8x8x2_t, poly8x8x3_t, poly8x8x4_t,
+    uint16x4_t, uint16x4x2_t, uint16x4x3_t, uint16x4x4_t, uint16x8_t,
+    uint16x8x2_t, uint16x8x3_t, uint16x8x4_t, uint32x2_t, uint32x2x2_t,
+    uint32x2x3_t, uint32x2x4_t, uint32x4_t, uint32x4x2_t, uint32x4x3_t,
+    uint32x4x4_t, uint64x1_t, uint64x1x2_t, uint64x1x3_t, uint64x1x4_t,
+    uint64x2_t, uint64x2x2_t, uint64x2x3_t, uint64x2x4_t, uint8x16_t,
+    uint8x16x2_t, uint8x16x3_t, uint8x16x4_t, uint8x8_t, uint8x8x2_t,
+    uint8x8x3_t, uint8x8x4_t,
+  }
 );
 
-#[cfg(target_arch = "x86")]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Pod for x86::{
-        __m128i, __m128, __m128d,
-        __m256i, __m256, __m256d,
-    }
+  #[cfg(target_arch = "x86")]
+  unsafe impl Pod for x86::{
+    __m128i, __m128, __m128d,
+    __m256i, __m256, __m256d,
+  }
 );
 
-#[cfg(target_arch = "x86_64")]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Pod for x86_64::{
-        __m128i, __m128, __m128d,
-        __m256i, __m256, __m256d,
-    }
+  #[cfg(target_arch = "x86_64")]
+  unsafe impl Pod for x86_64::{
+    __m128i, __m128, __m128d,
+    __m256i, __m256, __m256d,
+  }
 );
 
 #[cfg(feature = "nightly_portable_simd")]
-#[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "nightly_portable_simd")))]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(feature = "nightly_portable_simd"))
+)]
 unsafe impl<T, const N: usize> Pod for core::simd::Simd<T, N>
 where
   T: core::simd::SimdElement + Pod,
@@ -136,20 +148,18 @@ where
 {
 }
 
-#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
-#[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "nightly_stdsimd")))]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Pod for x86::{
-        __m128bh, __m256bh, __m512,
-        __m512bh, __m512d, __m512i,
-    }
+  #[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+  unsafe impl Pod for x86::{
+    __m128bh, __m256bh, __m512,
+    __m512bh, __m512d, __m512i,
+  }
 );
 
-#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
-#[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "nightly_stdsimd")))]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Pod for x86_64::{
-        __m128bh, __m256bh, __m512,
-        __m512bh, __m512d, __m512i,
-    }
+  #[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+  unsafe impl Pod for x86_64::{
+    __m128bh, __m256bh, __m512,
+    __m512bh, __m512d, __m512i,
+  }
 );

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -19,8 +19,8 @@ use super::*;
 ///
 /// * `MaybeUninit<T>` was not available in 1.34.0, but is available under the
 ///   `zeroable_maybe_uninit` feature flag.
-/// * `Atomic*` types require Rust 1.60.0 or later to work on certain platforms, but is available
-///   under the `zeroable_atomics` feature flag.
+/// * `Atomic*` types require Rust 1.60.0 or later to work on certain platforms,
+///   but is available under the `zeroable_atomics` feature flag.
 /// * `[T; N]` for arbitrary `N` requires the `min_const_generics` feature flag.
 pub unsafe trait Zeroable: Sized {
   /// Calls [`zeroed`](core::mem::zeroed).
@@ -107,7 +107,10 @@ mod atomic_impls {
 }
 
 #[cfg(feature = "zeroable_maybe_uninit")]
-#[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "zeroable_maybe_uninit")))]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(feature = "zeroable_maybe_uninit"))
+)]
 unsafe impl<T> Zeroable for core::mem::MaybeUninit<T> {}
 
 unsafe impl<A: Zeroable> Zeroable for (A,) {}
@@ -166,47 +169,47 @@ impl_unsafe_marker_for_array!(
   512, 1024, 2048, 4096
 );
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm_simd"))]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Zeroable for wasm32::{v128}
+  #[cfg(all(target_arch = "wasm32", feature = "wasm_simd"))]
+  unsafe impl Zeroable for wasm32::{v128}
 );
 
-#[cfg(all(target_arch = "aarch64", feature = "aarch64_simd"))]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Zeroable for aarch64::{
-        float32x2_t, float32x2x2_t, float32x2x3_t, float32x2x4_t, float32x4_t,
-        float32x4x2_t, float32x4x3_t, float32x4x4_t, float64x1_t, float64x1x2_t,
-        float64x1x3_t, float64x1x4_t, float64x2_t, float64x2x2_t, float64x2x3_t,
-        float64x2x4_t, int16x4_t, int16x4x2_t, int16x4x3_t, int16x4x4_t, int16x8_t,
-        int16x8x2_t, int16x8x3_t, int16x8x4_t, int32x2_t, int32x2x2_t, int32x2x3_t,
-        int32x2x4_t, int32x4_t, int32x4x2_t, int32x4x3_t, int32x4x4_t, int64x1_t,
-        int64x1x2_t, int64x1x3_t, int64x1x4_t, int64x2_t, int64x2x2_t, int64x2x3_t,
-        int64x2x4_t, int8x16_t, int8x16x2_t, int8x16x3_t, int8x16x4_t, int8x8_t,
-        int8x8x2_t, int8x8x3_t, int8x8x4_t, poly16x4_t, poly16x4x2_t, poly16x4x3_t,
-        poly16x4x4_t, poly16x8_t, poly16x8x2_t, poly16x8x3_t, poly16x8x4_t,
-        poly64x1_t, poly64x1x2_t, poly64x1x3_t, poly64x1x4_t, poly64x2_t,
-        poly64x2x2_t, poly64x2x3_t, poly64x2x4_t, poly8x16_t, poly8x16x2_t,
-        poly8x16x3_t, poly8x16x4_t, poly8x8_t, poly8x8x2_t, poly8x8x3_t, poly8x8x4_t,
-        uint16x4_t, uint16x4x2_t, uint16x4x3_t, uint16x4x4_t, uint16x8_t,
-        uint16x8x2_t, uint16x8x3_t, uint16x8x4_t, uint32x2_t, uint32x2x2_t,
-        uint32x2x3_t, uint32x2x4_t, uint32x4_t, uint32x4x2_t, uint32x4x3_t,
-        uint32x4x4_t, uint64x1_t, uint64x1x2_t, uint64x1x3_t, uint64x1x4_t,
-        uint64x2_t, uint64x2x2_t, uint64x2x3_t, uint64x2x4_t, uint8x16_t,
-        uint8x16x2_t, uint8x16x3_t, uint8x16x4_t, uint8x8_t, uint8x8x2_t,
-        uint8x8x3_t, uint8x8x4_t,
-      }
+  #[cfg(all(target_arch = "aarch64", feature = "aarch64_simd"))]
+  unsafe impl Zeroable for aarch64::{
+    float32x2_t, float32x2x2_t, float32x2x3_t, float32x2x4_t, float32x4_t,
+    float32x4x2_t, float32x4x3_t, float32x4x4_t, float64x1_t, float64x1x2_t,
+    float64x1x3_t, float64x1x4_t, float64x2_t, float64x2x2_t, float64x2x3_t,
+    float64x2x4_t, int16x4_t, int16x4x2_t, int16x4x3_t, int16x4x4_t, int16x8_t,
+    int16x8x2_t, int16x8x3_t, int16x8x4_t, int32x2_t, int32x2x2_t, int32x2x3_t,
+    int32x2x4_t, int32x4_t, int32x4x2_t, int32x4x3_t, int32x4x4_t, int64x1_t,
+    int64x1x2_t, int64x1x3_t, int64x1x4_t, int64x2_t, int64x2x2_t, int64x2x3_t,
+    int64x2x4_t, int8x16_t, int8x16x2_t, int8x16x3_t, int8x16x4_t, int8x8_t,
+    int8x8x2_t, int8x8x3_t, int8x8x4_t, poly16x4_t, poly16x4x2_t, poly16x4x3_t,
+    poly16x4x4_t, poly16x8_t, poly16x8x2_t, poly16x8x3_t, poly16x8x4_t,
+    poly64x1_t, poly64x1x2_t, poly64x1x3_t, poly64x1x4_t, poly64x2_t,
+    poly64x2x2_t, poly64x2x3_t, poly64x2x4_t, poly8x16_t, poly8x16x2_t,
+    poly8x16x3_t, poly8x16x4_t, poly8x8_t, poly8x8x2_t, poly8x8x3_t, poly8x8x4_t,
+    uint16x4_t, uint16x4x2_t, uint16x4x3_t, uint16x4x4_t, uint16x8_t,
+    uint16x8x2_t, uint16x8x3_t, uint16x8x4_t, uint32x2_t, uint32x2x2_t,
+    uint32x2x3_t, uint32x2x4_t, uint32x4_t, uint32x4x2_t, uint32x4x3_t,
+    uint32x4x4_t, uint64x1_t, uint64x1x2_t, uint64x1x3_t, uint64x1x4_t,
+    uint64x2_t, uint64x2x2_t, uint64x2x3_t, uint64x2x4_t, uint8x16_t,
+    uint8x16x2_t, uint8x16x3_t, uint8x16x4_t, uint8x8_t, uint8x8x2_t,
+    uint8x8x3_t, uint8x8x4_t,
+  }
 );
 
-#[cfg(target_arch = "x86")]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Zeroable for x86::{
-        __m128i, __m128, __m128d,
-        __m256i, __m256, __m256d,
-    }
+  #[cfg(target_arch = "x86")]
+  unsafe impl Zeroable for x86::{
+    __m128i, __m128, __m128d,
+    __m256i, __m256, __m256d,
+  }
 );
 
-#[cfg(target_arch = "x86_64")]
 impl_unsafe_marker_for_simd!(
+  #[cfg(target_arch = "x86_64")]
     unsafe impl Zeroable for x86_64::{
         __m128i, __m128, __m128d,
         __m256i, __m256, __m256d,
@@ -214,7 +217,10 @@ impl_unsafe_marker_for_simd!(
 );
 
 #[cfg(feature = "nightly_portable_simd")]
-#[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "nightly_portable_simd")))]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(feature = "nightly_portable_simd"))
+)]
 unsafe impl<T, const N: usize> Zeroable for core::simd::Simd<T, N>
 where
   T: core::simd::SimdElement + Zeroable,
@@ -222,20 +228,18 @@ where
 {
 }
 
-#[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
-#[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "nightly_std_simd")))]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Zeroable for x86::{
-        __m128bh, __m256bh, __m512,
-        __m512bh, __m512d, __m512i,
-    }
+  #[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+  unsafe impl Zeroable for x86::{
+    __m128bh, __m256bh, __m512,
+    __m512bh, __m512d, __m512i,
+  }
 );
 
-#[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
-#[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "nightly_std_simd")))]
 impl_unsafe_marker_for_simd!(
-    unsafe impl Zeroable for x86_64::{
-        __m128bh, __m256bh, __m512,
-        __m512bh, __m512d, __m512i,
-    }
+  #[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+  unsafe impl Zeroable for x86_64::{
+    __m128bh, __m256bh, __m512,
+    __m512bh, __m512d, __m512i,
+  }
 );


### PR DESCRIPTION
... so that the macro can correctly expand with `doc(cfg(...))` attributes under `feature = "nightly_docs"`.

(see https://github.com/Lokathor/bytemuck/pull/203#issuecomment-1707208974 )