### PR TITLE
Under `features = ["nightly_stdsimd"]`, only enable `stdarch_x86_avx512` feature on x86 or x86_64 targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,13 @@
 #![allow(clippy::uninlined_format_args)]
 #![cfg_attr(feature = "nightly_docs", feature(doc_cfg))]
 #![cfg_attr(feature = "nightly_portable_simd", feature(portable_simd))]
-#![cfg_attr(feature = "nightly_stdsimd", feature(stdarch_x86_avx512))]
+#![cfg_attr(
+  all(
+    feature = "nightly_stdsimd",
+    any(target_arch = "x86_64", target_arch = "x86")
+  ),
+  feature(stdarch_x86_avx512)
+)]
 
 //! This crate gives small utilities for casting between plain data types.
 //!


### PR DESCRIPTION
... as the feature does not exist on other targets.

```sh
$ cargo new mwe
$ cd mwe
$ cargo add bytemuck -F nightly_stdsimd
$ cargo +nightly build --target aarch64-unknown-linux-gnu
   Compiling bytemuck v1.14.2
error[E0635]: unknown feature `stdarch_x86_avx512`
 --> /home/zachary/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bytemuck-1.14.2/src/lib.rs:7:50
  |
7 | #![cfg_attr(feature = "nightly_stdsimd", feature(stdarch_x86_avx512))]
  |                                                  ^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0635`.
error: could not compile `bytemuck` (lib) due to 1 previous error
```