### PR TITLE
Convert `BoxBytes` to/from boxed slices

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -9,8 +9,6 @@
 //!   `bytemuck = { version = "VERSION_YOU_ARE_USING", features =
 //! ["extern_crate_alloc"]}`
 
-use self::sealed::BoxBytesOf;
-
 use super::*;
 #[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
@@ -782,9 +780,9 @@ impl<T: AnyBitPattern> sealed::FromBoxBytes for T {
   ) -> Result<Box<Self>, (PodCastError, BoxBytes)> {
     let layout = Layout::new::<T>();
     if bytes.layout.align() != layout.align() {
-      return Err((PodCastError::AlignmentMismatch, bytes));
+      Err((PodCastError::AlignmentMismatch, bytes))
     } else if bytes.layout.size() != layout.size() {
-      return Err((PodCastError::SizeMismatch, bytes));
+      Err((PodCastError::SizeMismatch, bytes))
     } else {
       let (ptr, _) = bytes.into_raw_parts();
       // SAFETY: See BoxBytes type invariant.
@@ -799,11 +797,11 @@ impl<T: AnyBitPattern> sealed::FromBoxBytes for [T] {
   ) -> Result<Box<Self>, (PodCastError, BoxBytes)> {
     let single_layout = Layout::new::<T>();
     if bytes.layout.align() != single_layout.align() {
-      return Err((PodCastError::AlignmentMismatch, bytes));
+      Err((PodCastError::AlignmentMismatch, bytes))
     } else if single_layout.size() == 0 {
-      return Err((PodCastError::SizeMismatch, bytes));
+      Err((PodCastError::SizeMismatch, bytes))
     } else if bytes.layout.size() % single_layout.size() != 0 {
-      return Err((PodCastError::OutputSliceWouldHaveSlop, bytes));
+      Err((PodCastError::OutputSliceWouldHaveSlop, bytes))
     } else {
       let (ptr, layout) = bytes.into_raw_parts();
       let length = layout.size() / single_layout.size();

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -729,17 +729,12 @@ impl Drop for BoxBytes {
   }
 }
 
-impl<T: NoUninit> From<Box<T>> for BoxBytes {
+impl<T: ?Sized + sealed::BoxBytesOf> From<Box<T>> for BoxBytes {
   fn from(value: Box<T>) -> Self {
     value.box_bytes_of()
   }
 }
 
-impl<T: NoUninit> From<Box<[T]>> for BoxBytes {
-  fn from(value: Box<[T]>) -> Self {
-    value.box_bytes_of()
-  }
-}
 mod sealed {
   use crate::{BoxBytes, PodCastError};
   use alloc::boxed::Box;
@@ -822,7 +817,8 @@ impl<T: AnyBitPattern> sealed::FromBoxBytes for [T] {
 
 /// Re-interprets `Box<T>` as `BoxBytes`.
 ///
-/// `T` must be either `Sized + NoUninit`, or `[U]` where `U: NoUninit`.
+/// `T` must be either [`Sized`] and [`NoUninit`],
+/// [`[U]`](slice) where `U: NoUninit`, or [`str`].
 #[inline]
 pub fn box_bytes_of<T: sealed::BoxBytesOf + ?Sized>(input: Box<T>) -> BoxBytes {
   input.box_bytes_of()
@@ -830,8 +826,8 @@ pub fn box_bytes_of<T: sealed::BoxBytesOf + ?Sized>(input: Box<T>) -> BoxBytes {
 
 /// Re-interprets `BoxBytes` as `Box<T>`.
 ///
-/// `T` must be either `Sized + AnyBitPattern`, or `[U]` where `U:
-/// AnyBitPattern`.
+/// `T` must be either [`Sized`] + [`AnyBitPattern`], or
+/// [`[U]`](slice) where `U: AnyBitPattern`.
 ///
 /// ## Panics
 ///
@@ -846,10 +842,14 @@ pub fn from_box_bytes<T: sealed::FromBoxBytes + ?Sized>(
 
 /// Re-interprets `BoxBytes` as `Box<T>`.
 ///
-/// ## Panics
+/// `T` must be either [`Sized`] + [`AnyBitPattern`], or
+/// [`[U]`](slice) where `U: AnyBitPattern`.
 ///
-/// * If the input isn't aligned for the new type
-/// * If the input's length isn’t exactly the size of the new type
+/// Returns `Err`:
+/// * If the input isn't aligned for `T`.
+/// * If `T: Sized` and the input's length isn't exactly the size of `T`.
+/// * If `T = [U]` and the input's length isn't exactly a multiple of the size
+///   of `U`.
 #[inline]
 pub fn try_from_box_bytes<T: sealed::FromBoxBytes + ?Sized>(
   input: BoxBytes,


### PR DESCRIPTION
As I mentioned [in a comment on the BoxBytes PR](https://github.com/Lokathor/bytemuck/pull/211#pullrequestreview-1675256320), `BoxBytes` logically can be converted to/from boxed slices as well as boxed `Sized` types. This PR extends the existing `box_bytes_of`/`(try_)from_box_bytes` using sealed traits to allow them to take/return boxed slices as well as their current boxed Sized types (and `Box<str>` for `box_bytes_of`).

<details> <summary>semver</summary>

The relaxation of the function bounds is not a breaking change.

The change from `impl<T: NoUninit> From<Box<T>> for BoxBytes` to `impl<T: ?Sized + BoxBytesOf> From<Box<T>> for BoxBytes` I believe is not a breaking change:

* Any type for which a downstream crate was previously allowed to implement `From<Box<U>> for BoxBytes` must have `U` as a local, non-`NoUninit` type, which as far as I can tell is still allowed under this new impl.
</details>