### PR TITLE
Update TransparentWrapper asserts

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -531,6 +531,11 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
   /// type.
   #[inline]
   fn wrap_box(s: Box<Inner>) -> Box<Self> {
+    // The unsafe contract requires that these two have
+    // identical representations, and thus identical pointer metadata.
+    // Assert that Self and Inner have the same pointer size,
+    // which is the best we can do to assert their metadata is the same type
+    // on stable.
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
 
     unsafe {
@@ -555,6 +560,11 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
   /// wrapper type.
   #[inline]
   fn wrap_rc(s: Rc<Inner>) -> Rc<Self> {
+    // The unsafe contract requires that these two have
+    // identical representations, and thus identical pointer metadata.
+    // Assert that Self and Inner have the same pointer size,
+    // which is the best we can do to assert their metadata is the same type
+    // on stable.
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
 
     unsafe {
@@ -578,6 +588,11 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
   #[inline]
   #[cfg(target_has_atomic = "ptr")]
   fn wrap_arc(s: Arc<Inner>) -> Arc<Self> {
+    // The unsafe contract requires that these two have
+    // identical representations, and thus identical pointer metadata.
+    // Assert that Self and Inner have the same pointer size,
+    // which is the best we can do to assert their metadata is the same type
+    // on stable.
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
 
     unsafe {
@@ -621,6 +636,11 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
   /// type.
   #[inline]
   fn peel_box(s: Box<Self>) -> Box<Inner> {
+    // The unsafe contract requires that these two have
+    // identical representations, and thus identical pointer metadata.
+    // Assert that Self and Inner have the same pointer size,
+    // which is the best we can do to assert their metadata is the same type
+    // on stable.
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
 
     unsafe {
@@ -645,6 +665,11 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
   /// inner type.
   #[inline]
   fn peel_rc(s: Rc<Self>) -> Rc<Inner> {
+    // The unsafe contract requires that these two have
+    // identical representations, and thus identical pointer metadata.
+    // Assert that Self and Inner have the same pointer size,
+    // which is the best we can do to assert their metadata is the same type
+    // on stable.
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
 
     unsafe {
@@ -668,6 +693,11 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
   #[inline]
   #[cfg(target_has_atomic = "ptr")]
   fn peel_arc(s: Arc<Self>) -> Arc<Inner> {
+    // The unsafe contract requires that these two have
+    // identical representations, and thus identical pointer metadata.
+    // Assert that Self and Inner have the same pointer size,
+    // which is the best we can do to assert their metadata is the same type
+    // on stable.
     assert!(size_of::<*mut Inner>() == size_of::<*mut Self>());
 
     unsafe {


### PR DESCRIPTION
1. Fixed the `{wrap/peel}_slice` methods asserts: previously they were comparing the layouts of `*const Inner` and `*const Self`, which is are always the same when they're both `Sized`; now they check that `Inner` and `Self` have the same layout.
   * This could cause panics for existing users with incorrect `TransparentWrapper` implementations.
2. Added asserts to `wrap` and `peel`.
   * This could cause panics for existing users with incorrect `TransparentWrapper` implementations.
3. Added comments explaining why we compare size of `*const Self` in `{wrap/peel}_{ref/mut/rc/arc/box}`.
4. Moved some of the asserts and safety comments before the `unsafe` blocks (no semantic change, I just prefer it).

(I was going to also change the `assert!`s to `debug_assert!`s, but since the conditions are all const-foldable anyway, the only affect that would have would be hiding UB in release mode, with no benefit for correct implementations, so I left it using `assert!`)