### PR TITLE
support deriving Zeroable for fieldless enums

### DIFF
--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -50,6 +50,14 @@ struct ZeroGeneric<T: bytemuck::Zeroable> {
   a: T,
 }
 
+#[derive(Zeroable)]
+#[repr(u8)]
+enum ZeroEnum {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+
 #[derive(TransparentWrapper)]
 #[repr(transparent)]
 struct TransparentSingle {


### PR DESCRIPTION
This PR makes it possible to derive `Zeroable` on enums under the following conditions:
- The enum has an integer repr set using `#[repr(Int)]`.
- The enum is fieldless (this restriction could be relaxed in the future).
- There is a variant whose discriminant is 0.