### PR TITLE
Add a const zeroed()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ aarch64_simd = [] # MSRV 1.59.0: support aarch64 simd types
 
 must_cast = [] # MSRV 1.57.0: support the `must` module.
 
+const_zeroed = [] # MSRV 1.75.0: support const `zeroed()`
+
 # Do not use if you can avoid it, because this is **unsound**!!!!
 unsound_ptr_pod_impl = []
 
@@ -59,6 +61,7 @@ features = [
   "min_const_generics",
   "wasm_simd",
   "must_cast",
+  "const_zeroed",
 ]
 
 [package.metadata.playground]
@@ -72,4 +75,5 @@ features = [
   "min_const_generics",
   "wasm_simd",
   "must_cast",
+  "const_zeroed",
 ]

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -19,6 +19,7 @@ use alloc::{
   vec,
   vec::Vec,
 };
+use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
 
 /// As [`try_cast_box`](try_cast_box), but unwraps for you.
@@ -286,7 +287,7 @@ pub fn try_cast_vec<A: NoUninit, B: AnyBitPattern>(
 pub fn pod_collect_to_vec<A: NoUninit, B: NoUninit + AnyBitPattern>(
   src: &[A],
 ) -> Vec<B> {
-  let src_size = size_of_val(src);
+  let src_size = core::mem::size_of_val(src);
   // Note(Lokathor): dst_count is rounded up so that the dest will always be at
   // least as many bytes as the src.
   let dst_count = src_size / size_of::<B>()
@@ -512,7 +513,7 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
     Self: Sized,
     Inner: Sized,
   {
-    let mut s = core::mem::ManuallyDrop::new(s);
+    let mut s = ManuallyDrop::new(s);
 
     let length = s.len();
     let capacity = s.capacity();
@@ -617,7 +618,7 @@ pub trait TransparentWrapperAlloc<Inner: ?Sized>:
     Self: Sized,
     Inner: Sized,
   {
-    let mut s = core::mem::ManuallyDrop::new(s);
+    let mut s = ManuallyDrop::new(s);
 
     let length = s.len();
     let capacity = s.capacity();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@
 //!   instead of just for a select list of array lengths.
 //! * `must_cast`: Provides the `must_` functions, which will compile error if
 //!   the requested cast can't be statically verified.
+//! * `const_zeroed`: Provides the const [`zeroed`] function.
 
 #[cfg(all(target_arch = "aarch64", feature = "aarch64_simd"))]
 use core::arch::aarch64;
@@ -93,7 +94,12 @@ use core::arch::x86;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64;
 //
-use core::{marker::*, mem::*, num::*, ptr::*};
+use core::{
+  marker::*,
+  mem::{align_of, size_of},
+  num::*,
+  ptr::*,
+};
 
 // Used from macros to ensure we aren't using some locally defined name and
 // actually are referencing libcore. This also would allow pre-2018 edition
@@ -505,4 +511,13 @@ pub fn fill_zeroes<T: Zeroable>(slice: &mut [T]) {
     let len = core::mem::size_of_val::<[T]>(slice);
     unsafe { core::ptr::write_bytes(slice.as_mut_ptr() as *mut u8, 0u8, len) }
   }
+}
+
+/// Initialize a zeroed `T`.
+///
+/// Like [`Zeroable::zeroed`], but supports const.
+#[cfg(feature = "const_zeroed")]
+#[inline]
+pub const fn zeroed<T: Zeroable>() -> T {
+  unsafe { core::mem::zeroed() }
 }

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -74,7 +74,7 @@ unsafe impl<T: 'static> PodInOption for NonNull<T> {}
 
 unsafe impl<T: ?Sized + 'static> Pod for PhantomData<T> {}
 unsafe impl Pod for PhantomPinned {}
-unsafe impl<T: Pod> Pod for ManuallyDrop<T> {}
+unsafe impl<T: Pod> Pod for core::mem::ManuallyDrop<T> {}
 
 // Note(Lokathor): MaybeUninit can NEVER be Pod.
 

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -66,7 +66,7 @@ unsafe impl Zeroable for *const str {}
 
 unsafe impl<T: ?Sized> Zeroable for PhantomData<T> {}
 unsafe impl Zeroable for PhantomPinned {}
-unsafe impl<T: Zeroable> Zeroable for ManuallyDrop<T> {}
+unsafe impl<T: Zeroable> Zeroable for core::mem::ManuallyDrop<T> {}
 unsafe impl<T: Zeroable> Zeroable for core::cell::UnsafeCell<T> {}
 unsafe impl<T: Zeroable> Zeroable for core::cell::Cell<T> {}
 


### PR DESCRIPTION
This uses the same implementation as Zeroable::zeroed, but being outside the trait it is able to be const. Adds the "const_zeroed" feature, because const mem::zeroed requires rust 1.75.0.

Import changes are due to "zeroed" previously being a private import from mem::*