### PR TITLE
Address `unexpected_cfgs` warnings instead of allowing the lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ nightly_docs = []
 [dependencies]
 bytemuck_derive = { version = "1.4", path = "derive", optional = true }
 
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(target_arch, values("spirv"))'] }
+
 [package.metadata.docs.rs]
 # Note(Lokathor): Don't use all-features or it would use `unsound_ptr_pod_impl` too.
 features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![warn(missing_docs)]
-#![allow(unexpected_cfgs)]
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::uninlined_format_args)]
 #![cfg_attr(feature = "nightly_docs", feature(doc_cfg))]


### PR DESCRIPTION
r? @Lokathor