### PR TITLE
Don't require T to be AnyBitPattern for MaybeUninit<T> to be AnyBitPattern

### DIFF
--- a/src/anybitpattern.rs
+++ b/src/anybitpattern.rs
@@ -60,5 +60,6 @@ unsafe impl<T: Pod> AnyBitPattern for T {}
   feature = "nightly_docs",
   doc(cfg(feature = "zeroable_maybe_uninit"))
 )]
-unsafe impl<T> AnyBitPattern for core::mem::MaybeUninit<T> where T: AnyBitPattern
+unsafe impl<T> AnyBitPattern for core::mem::MaybeUninit<T> where
+  T: Copy + 'static
 {}


### PR DESCRIPTION
`MaybeUninit<T>` is always valid for any bit pattern even if `T` is not.