### PR TITLE
Support `Zeroable` and `Pod` for `f16` and `f128`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ unsound_ptr_pod_impl = []
 # NOT SEMVER SUPPORTED! TEMPORARY ONLY!
 nightly_portable_simd = []
 nightly_stdsimd = []
+# Enable `f16` and `f128`
+nightly_float = []
 
 # Improved documentation using the nightly toolchain
 nightly_docs = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::type_complexity)]
 #![cfg_attr(feature = "nightly_docs", feature(doc_cfg))]
 #![cfg_attr(feature = "nightly_portable_simd", feature(portable_simd))]
+#![cfg_attr(feature = "nightly_float", feature(f16, f128))]
 #![cfg_attr(
   all(
     feature = "nightly_stdsimd",

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -49,8 +49,12 @@ unsafe impl Pod for usize {}
 unsafe impl Pod for isize {}
 unsafe impl Pod for u128 {}
 unsafe impl Pod for i128 {}
+#[cfg(feature = "nightly_float")]
+unsafe impl Pod for f16 {}
 unsafe impl Pod for f32 {}
 unsafe impl Pod for f64 {}
+#[cfg(feature = "nightly_float")]
+unsafe impl Pod for f128 {}
 unsafe impl<T: Pod> Pod for Wrapping<T> {}
 
 #[cfg(feature = "unsound_ptr_pod_impl")]

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -48,8 +48,12 @@ unsafe impl Zeroable for usize {}
 unsafe impl Zeroable for isize {}
 unsafe impl Zeroable for u128 {}
 unsafe impl Zeroable for i128 {}
+#[cfg(feature = "nightly_float")]
+unsafe impl Zeroable for f16 {}
 unsafe impl Zeroable for f32 {}
 unsafe impl Zeroable for f64 {}
+#[cfg(feature = "nightly_float")]
+unsafe impl Zeroable for f128 {}
 unsafe impl<T: Zeroable> Zeroable for Wrapping<T> {}
 unsafe impl<T: Zeroable> Zeroable for core::cmp::Reverse<T> {}
 


### PR DESCRIPTION
These are gated under a new feature flag `nightly_float`.

Fixes: <https://github.com/Lokathor/bytemuck/issues/250>