### PR TITLE
Disallow casting ZST <-> non-ZST in cast_slice_box.

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -21,7 +21,7 @@ use alloc::{
   vec::Vec,
 };
 use core::{
-  mem::ManuallyDrop,
+  mem::{size_of_val, ManuallyDrop},
   ops::{Deref, DerefMut},
 };
 
@@ -172,9 +172,14 @@ pub fn try_cast_slice_box<A: NoUninit, B: AnyBitPattern>(
   if align_of::<A>() != align_of::<B>() {
     Err((PodCastError::AlignmentMismatch, input))
   } else if size_of::<A>() != size_of::<B>() {
-    if size_of::<A>() * input.len() % size_of::<B>() != 0 {
+    let input_bytes = size_of_val::<[A]>(&*input);
+    if size_of::<A>() == 0
+      || size_of::<B>() == 0
+      || input_bytes % size_of::<B>() != 0
+    {
       // If the size in bytes of the underlying buffer does not match an exact
-      // multiple of the size of B, we cannot cast between them.
+      // multiple of the size of B, or exactly one of A and B is a ZST, we
+      // cannot cast between them.
       Err((PodCastError::SizeMismatch, input))
     } else {
       // Because the size is an exact multiple, we can now change the length
@@ -185,7 +190,7 @@ pub fn try_cast_slice_box<A: NoUninit, B: AnyBitPattern>(
       // Luckily, Layout only stores two things, the alignment, and the size in
       // bytes. So as long as both of those stay the same, the Layout will
       // remain a valid input to dealloc.
-      let length = size_of::<A>() * input.len() / size_of::<B>();
+      let length = input_bytes / size_of::<B>();
       let box_ptr: *mut A = Box::into_raw(input) as *mut A;
       let ptr: *mut [B] =
         unsafe { core::slice::from_raw_parts_mut(box_ptr as *mut B, length) };
@@ -222,15 +227,19 @@ pub fn try_cast_vec<A: NoUninit, B: AnyBitPattern>(
   if align_of::<A>() != align_of::<B>() {
     Err((PodCastError::AlignmentMismatch, input))
   } else if size_of::<A>() != size_of::<B>() {
-    if size_of::<A>() * input.len() % size_of::<B>() != 0
-      || size_of::<A>() * input.capacity() % size_of::<B>() != 0
+    let input_size = size_of_val::<[A]>(&*input);
+    let input_capacity = input.capacity() * size_of::<A>();
+    if size_of::<A>() == 0
+      || size_of::<B>() == 0
+      || input_size % size_of::<B>() != 0
+      || input_capacity % size_of::<B>() != 0
     {
       // If the size in bytes of the underlying buffer does not match an exact
-      // multiple of the size of B, we cannot cast between them.
-      // Note that we have to pay special attention to make sure that both
-      // length and capacity are valid under B, as we do not want to
-      // change which bytes are considered part of the initialized slice
-      // of the Vec
+      // multiple of the size of B, or exactly one of A and B is a ZST, we
+      // cannot cast between them. Note that we have to pay special
+      // attention to make sure that both length and capacity are valid
+      // under B, as we do not want to change which bytes are considered
+      // part of the initialized slice of the Vec
       Err((PodCastError::SizeMismatch, input))
     } else {
       // Because the size is an exact multiple, we can now change the length and
@@ -244,8 +253,8 @@ pub fn try_cast_vec<A: NoUninit, B: AnyBitPattern>(
 
       // Note(Lokathor): First we record the length and capacity, which don't
       // have any secret provenance metadata.
-      let length: usize = size_of::<A>() * input.len() / size_of::<B>();
-      let capacity: usize = size_of::<A>() * input.capacity() / size_of::<B>();
+      let length: usize = input_size / size_of::<B>();
+      let capacity: usize = input_capacity / size_of::<B>();
       // Note(Lokathor): Next we "pre-forget" the old Vec by wrapping with
       // ManuallyDrop, because if we used `core::mem::forget` after taking the
       // pointer then that would invalidate our pointer. In nightly there's a
@@ -415,9 +424,14 @@ pub fn try_cast_slice_rc<
   if align_of::<A>() != align_of::<B>() {
     Err((PodCastError::AlignmentMismatch, input))
   } else if size_of::<A>() != size_of::<B>() {
-    if size_of::<A>() * input.len() % size_of::<B>() != 0 {
+    let input_bytes = size_of_val::<[A]>(&*input);
+    if size_of::<A>() == 0
+      || size_of::<B>() == 0
+      || input_bytes % size_of::<B>() != 0
+    {
       // If the size in bytes of the underlying buffer does not match an exact
-      // multiple of the size of B, we cannot cast between them.
+      // multiple of the size of B, or exactly one of A and B is a ZST, we
+      // cannot cast between them.
       Err((PodCastError::SizeMismatch, input))
     } else {
       // Because the size is an exact multiple, we can now change the length
@@ -427,7 +441,7 @@ pub fn try_cast_slice_rc<
       // acquired from Rc::into_raw() must have the same size alignment and
       // size of the type T in the new Rc<T>. So as long as both the size
       // and alignment stay the same, the Rc will remain a valid Rc.
-      let length = size_of::<A>() * input.len() / size_of::<B>();
+      let length = input_bytes / size_of::<B>();
       let rc_ptr: *const A = Rc::into_raw(input) as *const A;
       // Must use ptr::slice_from_raw_parts, because we cannot make an
       // intermediate const reference, because it has mutable provenance,
@@ -479,9 +493,14 @@ pub fn try_cast_slice_arc<
   if align_of::<A>() != align_of::<B>() {
     Err((PodCastError::AlignmentMismatch, input))
   } else if size_of::<A>() != size_of::<B>() {
-    if size_of::<A>() * input.len() % size_of::<B>() != 0 {
+    let input_bytes = size_of_val::<[A]>(&*input);
+    if size_of::<A>() == 0
+      || size_of::<B>() == 0
+      || input_bytes % size_of::<B>() != 0
+    {
       // If the size in bytes of the underlying buffer does not match an exact
-      // multiple of the size of B, we cannot cast between them.
+      // multiple of the size of B, or exactly one of A and B is a ZST, we
+      // cannot cast between them.
       Err((PodCastError::SizeMismatch, input))
     } else {
       // Because the size is an exact multiple, we can now change the length
@@ -491,7 +510,7 @@ pub fn try_cast_slice_arc<
       // acquired from Arc::into_raw() must have the same size alignment and
       // size of the type T in the new Arc<T>. So as long as both the size
       // and alignment stay the same, the Arc will remain a valid Arc.
-      let length = size_of::<A>() * input.len() / size_of::<B>();
+      let length = input_bytes / size_of::<B>();
       let arc_ptr: *const A = Arc::into_raw(input) as *const A;
       // Must use ptr::slice_from_raw_parts, because we cannot make an
       // intermediate const reference, because it has mutable provenance,

--- a/tests/cast_slice_tests.rs
+++ b/tests/cast_slice_tests.rs
@@ -195,3 +195,145 @@ fn test_panics() {
   let aligned_bytes = bytemuck::cast_slice::<u32, u8>(&[0, 0]);
   should_panic!(from_bytes::<u32>(&aligned_bytes[1..5]));
 }
+
+#[cfg(feature = "extern_crate_alloc")]
+#[test]
+fn test_boxed_slices() {
+  let boxed_u8_slice: Box<[u8]> = Box::new([0, 1, u8::MAX, i8::MAX as u8]);
+  let boxed_i8_slice: Box<[i8]> = cast_slice_box::<u8, i8>(boxed_u8_slice);
+  assert_eq!(&*boxed_i8_slice, [0, 1, -1, i8::MAX]);
+
+  let result: Result<Box<[u16]>, (PodCastError, Box<[i8]>)> =
+    try_cast_slice_box(boxed_i8_slice);
+  let (error, boxed_i8_slice) =
+    result.expect_err("u16 and i8 have different alignment");
+  assert_eq!(error, PodCastError::AlignmentMismatch);
+
+  // FIXME(#253): Should these next two casts' errors be consistent?
+  let result: Result<&[[i8; 3]], PodCastError> =
+    try_cast_slice(&*boxed_i8_slice);
+  let error =
+    result.expect_err("slice of [i8; 3] cannot be made from slice of 4 i8s");
+  assert_eq!(error, PodCastError::OutputSliceWouldHaveSlop);
+
+  let result: Result<Box<[[i8; 3]]>, (PodCastError, Box<[i8]>)> =
+    try_cast_slice_box(boxed_i8_slice);
+  let (error, _) =
+    result.expect_err("slice of [i8; 3] cannot be made from slice of 4 i8s");
+  assert_eq!(error, PodCastError::SizeMismatch);
+
+  assert_eq!(
+    try_cast_slice_box::<u8, ()>(Box::new([])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+
+  assert_eq!(
+    try_cast_slice_box::<u8, ()>(Box::new([1, 2, 3])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+
+  assert_eq!(
+    try_cast_slice_box::<(), i8>(Box::new([])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+
+  assert_eq!(
+    try_cast_slice_box::<(), i8>(Box::new([(); 42])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+}
+
+#[cfg(feature = "extern_crate_alloc")]
+#[test]
+fn test_rc_slices() {
+  use std::rc::Rc;
+  let rc_u8_slice: Rc<[u8]> = Rc::new([0, 1, u8::MAX, i8::MAX as u8]);
+  let rc_i8_slice: Rc<[i8]> = cast_slice_rc::<u8, i8>(rc_u8_slice);
+  assert_eq!(&*rc_i8_slice, [0, 1, -1, i8::MAX]);
+
+  let result: Result<Rc<[u16]>, (PodCastError, Rc<[i8]>)> =
+    try_cast_slice_rc(rc_i8_slice);
+  let (error, rc_i8_slice) =
+    result.expect_err("u16 and i8 have different alignment");
+  assert_eq!(error, PodCastError::AlignmentMismatch);
+
+  // FIXME(#253): Should these next two casts' errors be consistent?
+  let result: Result<&[[i8; 3]], PodCastError> = try_cast_slice(&*rc_i8_slice);
+  let error =
+    result.expect_err("slice of [i8; 3] cannot be made from slice of 4 i8s");
+  assert_eq!(error, PodCastError::OutputSliceWouldHaveSlop);
+
+  let result: Result<Rc<[[i8; 3]]>, (PodCastError, Rc<[i8]>)> =
+    try_cast_slice_rc(rc_i8_slice);
+  let (error, _) =
+    result.expect_err("slice of [i8; 3] cannot be made from slice of 4 i8s");
+  assert_eq!(error, PodCastError::SizeMismatch);
+
+  assert_eq!(
+    try_cast_slice_rc::<u8, ()>(Rc::new([])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+
+  assert_eq!(
+    try_cast_slice_rc::<u8, ()>(Rc::new([1, 2, 3])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+
+  assert_eq!(
+    try_cast_slice_rc::<(), i8>(Rc::new([])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+
+  assert_eq!(
+    try_cast_slice_rc::<(), i8>(Rc::new([(); 42])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+}
+
+#[cfg(feature = "extern_crate_alloc")]
+#[cfg(target_has_atomic = "ptr")]
+#[test]
+fn test_arc_slices() {
+  use std::sync::Arc;
+  let arc_u8_slice: Arc<[u8]> = Arc::new([0, 1, u8::MAX, i8::MAX as u8]);
+  let arc_i8_slice: Arc<[i8]> = cast_slice_arc::<u8, i8>(arc_u8_slice);
+  assert_eq!(&*arc_i8_slice, [0, 1, -1, i8::MAX]);
+
+  let result: Result<Arc<[u16]>, (PodCastError, Arc<[i8]>)> =
+    try_cast_slice_arc(arc_i8_slice);
+  let (error, arc_i8_slice) =
+    result.expect_err("u16 and i8 have different alignment");
+  assert_eq!(error, PodCastError::AlignmentMismatch);
+
+  // FIXME(#253): Should these next two casts' errors be consistent?
+  let result: Result<&[[i8; 3]], PodCastError> = try_cast_slice(&*arc_i8_slice);
+  let error =
+    result.expect_err("slice of [i8; 3] cannot be made from slice of 4 i8s");
+  assert_eq!(error, PodCastError::OutputSliceWouldHaveSlop);
+
+  let result: Result<Arc<[[i8; 3]]>, (PodCastError, Arc<[i8]>)> =
+    try_cast_slice_arc(arc_i8_slice);
+  let (error, _) =
+    result.expect_err("slice of [i8; 3] cannot be made from slice of 4 i8s");
+  assert_eq!(error, PodCastError::SizeMismatch);
+
+  assert_eq!(
+    try_cast_slice_arc::<u8, ()>(Arc::new([])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+
+  assert_eq!(
+    try_cast_slice_arc::<u8, ()>(Arc::new([1, 2, 3])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+
+  assert_eq!(
+    try_cast_slice_arc::<(), i8>(Arc::new([])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+
+  assert_eq!(
+    try_cast_slice_arc::<(), i8>(Arc::new([(); 42])).unwrap_err().0,
+    PodCastError::SizeMismatch
+  );
+}


### PR DESCRIPTION
Alternative to #254. Fixes the panics in `try_cast_slice_box` by disallowing casting between boxed ZST slices and boxed non-ZST slices, regardless of length (i.e. option 3 from #253 "Make cast_slice_box behave like cast_slice").