### PR TITLE
Allow casting between slices of ZSTs and slices of non-ZSTs in all cases.

### DIFF
--- a/src/checked.rs
+++ b/src/checked.rs
@@ -368,8 +368,6 @@ pub fn try_cast_mut<
 ///   type, and the output slice wouldn't be a whole number of elements when
 ///   accounting for the size change (eg: 3 `u16` values is 1.5 `u32` values, so
 ///   that's a failure).
-/// * Similarly, you can't convert between a [ZST](https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts)
-///   and a non-ZST.
 /// * If any element of the converted slice would contain an invalid bit pattern
 ///   for `B` this fails.
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,15 +198,14 @@ pub use bytemuck_derive::{
 /// The things that can go wrong when casting between [`Pod`] data forms.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PodCastError {
-  /// You tried to cast a slice to an element type with a higher alignment
-  /// requirement but the slice wasn't aligned.
+  /// You tried to cast a reference into a reference to a type with a higher alignment
+  /// requirement but the input reference wasn't aligned.
   TargetAlignmentGreaterAndInputNotAligned,
-  /// If the element size changes then the output slice changes length
-  /// accordingly. If the output slice wouldn't be a whole number of elements
+  /// If the element size of a slice changes, then the output slice changes length
+  /// accordingly. If the output slice wouldn't be a whole number of elements,
   /// then the conversion fails.
   OutputSliceWouldHaveSlop,
-  /// When casting a slice you can't convert between ZST elements and non-ZST
-  /// elements. When casting an individual `T`, `&T`, or `&mut T` value the
+  /// When casting an individual `T`, `&T`, or `&mut T` value the
   /// source size and destination size must be an exact match.
   SizeMismatch,
   /// For this type of cast the alignments must be exactly the same and they


### PR DESCRIPTION
Closes #253.

> having ZST slices turn into 0-length non-ZST slices does seem like a compelling path.

This PR implements that. Additionally, casting non-ZST slices to ZST slices will work iff the input slice has length 0, and results in a slice length of 0; if the input slice is not of length 0, `PodCastError::OutputSliceWouldHaveSlop` is returned.

Updates the docs of the `PodCastError` variants to reflect when they can occur.
Updates the docs of `try_cast_slice` (and `checked::`) to remove note about ZST <-> non-ZST not being allowed.
Update `bytes_of(_mut)` to remove ZST-may-not-have-same-address exception, since casting [ZST] -> [u8] is now allowed directly using `cast_slice(_mut)` (but does not remove the documentation of the exception just in case).
Update `must_cast_slice` checks and doctests to allow [ZST] -> [non-ZST], but disallow [non-ZST] -> [ZST].