### PR TITLE
derive(Zeroable) on fieldful enums and repr(C) enums

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -116,7 +116,7 @@ pub fn derive_anybitpattern(
 
 /// Derive the `Zeroable` trait for a type.
 ///
-/// The macro ensures that the struct follows all the the safety requirements
+/// The macro ensures that the type follows all the the safety requirements
 /// for the `Zeroable` trait.
 ///
 /// The following constraints need to be satisfied for the macro to succeed on a
@@ -133,7 +133,7 @@ pub fn derive_anybitpattern(
 /// - All fields in the variant with discriminant 0 (if any) must implement
 ///   `Zeroable`
 ///
-/// The macro always succeeds on `union`s.
+/// The macro always succeeds on unions.
 ///
 /// ## Example
 ///

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -6,7 +6,7 @@ mod traits;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Result};
+use syn::{parse_macro_input, DeriveInput, Result, Variant};
 
 use crate::traits::{
   bytemuck_crate_name, AnyBitPattern, CheckedBitPattern, Contiguous, Derivable,
@@ -114,14 +114,26 @@ pub fn derive_anybitpattern(
   proc_macro::TokenStream::from(expanded)
 }
 
-/// Derive the `Zeroable` trait for a struct
+/// Derive the `Zeroable` trait for a type.
 ///
 /// The macro ensures that the struct follows all the the safety requirements
 /// for the `Zeroable` trait.
 ///
-/// The following constraints need to be satisfied for the macro to succeed
+/// The following constraints need to be satisfied for the macro to succeed on a
+/// struct:
 ///
-/// - All fields in the struct must to implement `Zeroable`
+/// - All fields in the struct must implement `Zeroable`
+///
+/// The following constraints need to be satisfied for the macro to succeed on
+/// an enum:
+///
+/// - The enum has an explicit `#[repr(Int)]`, `#[repr(C)]`, or `#[repr(C,
+///   Int)]`.
+/// - The enum has a variant with discriminant 0 (explicitly or implicitly).
+/// - All fields in the variant with discriminant 0 (if any) must implement
+///   `Zeroable`
+///
+/// The macro always succeeds on `union`s.
 ///
 /// ## Example
 ///
@@ -132,6 +144,23 @@ pub fn derive_anybitpattern(
 /// struct Test {
 ///   a: u16,
 ///   b: u16,
+/// }
+/// ```
+/// ```rust
+/// # use bytemuck_derive::{Zeroable};
+/// #[derive(Copy, Clone, Zeroable)]
+/// #[repr(i32)]
+/// enum Values {
+///   A = 0,
+///   B = 1,
+///   C = 2,
+/// }
+/// #[derive(Clone, Zeroable)]
+/// #[repr(C)]
+/// enum Implicit {
+///   A(bool, u8, char),
+///   B(String),
+///   C(std::num::NonZeroU8),
 /// }
 /// ```
 ///
@@ -156,6 +185,18 @@ pub fn derive_anybitpattern(
 /// }
 ///
 /// AlwaysZeroable::<std::num::NonZeroU8>::zeroed();
+/// ```
+/// ```rust
+/// # use bytemuck::{Zeroable};
+/// #[derive(Copy, Clone, Zeroable)]
+/// #[repr(u8)]
+/// #[zeroable(bound = "")]
+/// enum MyOption<T> {
+///   None,
+///   Some(T),
+/// }
+///
+/// assert!(matches!(MyOption::<std::num::NonZeroU8>::zeroed(), MyOption::None));
 /// ```
 ///
 /// ```rust,compile_fail
@@ -407,7 +448,8 @@ pub fn derive_byte_eq(
   let input = parse_macro_input!(input as DeriveInput);
   let crate_name = bytemuck_crate_name(&input);
   let ident = input.ident;
-  let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+  let (impl_generics, ty_generics, where_clause) =
+    input.generics.split_for_impl();
 
   proc_macro::TokenStream::from(quote! {
     impl #impl_generics ::core::cmp::PartialEq for #ident #ty_generics #where_clause {
@@ -460,7 +502,8 @@ pub fn derive_byte_hash(
   let input = parse_macro_input!(input as DeriveInput);
   let crate_name = bytemuck_crate_name(&input);
   let ident = input.ident;
-  let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+  let (impl_generics, ty_generics, where_clause) =
+    input.generics.split_for_impl();
 
   proc_macro::TokenStream::from(quote! {
     impl #impl_generics ::core::hash::Hash for #ident #ty_generics #where_clause {
@@ -569,25 +612,28 @@ fn derive_marker_trait_inner<Trait: Derivable>(
         .flatten()
         .collect::<Vec<syn::WherePredicate>>();
 
-      let predicates = &mut input.generics.make_where_clause().predicates;
-
-      predicates.extend(explicit_bounds);
-
-      let fields = match &input.data {
-        syn::Data::Struct(syn::DataStruct { fields, .. }) => fields.clone(),
-        syn::Data::Union(_) => {
+      let fields = match (Trait::perfect_derive_fields(&input), &input.data) {
+        (Some(fields), _) => fields,
+        (None, syn::Data::Struct(syn::DataStruct { fields, .. })) => {
+          fields.clone()
+        }
+        (None, syn::Data::Union(_)) => {
           return Err(syn::Error::new_spanned(
             trait_,
             &"perfect derive is not supported for unions",
           ));
         }
-        syn::Data::Enum(_) => {
+        (None, syn::Data::Enum(_)) => {
           return Err(syn::Error::new_spanned(
             trait_,
             &"perfect derive is not supported for enums",
           ));
         }
       };
+
+      let predicates = &mut input.generics.make_where_clause().predicates;
+
+      predicates.extend(explicit_bounds);
 
       for field in fields {
         let ty = field.ty;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -6,7 +6,7 @@ mod traits;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Result, Variant};
+use syn::{parse_macro_input, DeriveInput, Result};
 
 use crate::traits::{
   bytemuck_crate_name, AnyBitPattern, CheckedBitPattern, Contiguous, Derivable,

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -49,7 +49,7 @@ pub trait Derivable {
   /// should be overridden to return `Some`.
   ///
   /// The default is "the fields of a struct; unions and enums not supported".
-  fn perfect_derive_fields(input: &DeriveInput) -> Option<Fields> {
+  fn perfect_derive_fields(_input: &DeriveInput) -> Option<Fields> {
     None
   }
 }

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -44,6 +44,11 @@ pub trait Derivable {
   fn explicit_bounds_attribute_name() -> Option<&'static str> {
     None
   }
+
+  /// If this trait has a custom meaning for "perfect derive", this function
+  /// should be overridden to return `Some`.
+  ///
+  /// The default is "the fields of a struct; unions and enums not supported".
   fn perfect_derive_fields(input: &DeriveInput) -> Option<Fields> {
     None
   }

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -551,6 +551,11 @@ fn get_struct_fields(input: &DeriveInput) -> Result<&Fields> {
   }
 }
 
+/// Extract the `Fields` off a `DeriveInput`, or, in the `enum` case, off
+/// those of the `enum_variant`, when provided (e.g., for `Zeroable`).
+/// 
+/// We purposely allow not providing an `enum_variant` for cases where
+/// the caller wants to reject supporting `enum`s (e.g., `NoPadding`).
 fn get_fields(
   input: &DeriveInput, enum_variant: Option<&Variant>,
 ) -> Result<Fields> {

--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -963,7 +963,8 @@ fn generate_checked_bit_pattern_enum_with_fields(
 fn generate_assert_no_padding(input: &DeriveInput) -> Result<TokenStream> {
   let struct_type = &input.ident;
   let span = input.ident.span();
-  let fields = get_fields(input, None)?;
+  let enum_variant = None; // `no padding` check is not supported for `enum`s yet.
+  let fields = get_fields(input, enum_variant)?;
 
   let mut field_types = get_field_types(&fields);
   let size_sum = if let Some(first) = field_types.next() {


### PR DESCRIPTION
Closes #230.

Allows deriving `Zeroable` on `enum`s where:

1. The enum is `#[repr(Int)]`, `#[repr(C)]`, or `#[repr(C, Int)]`,
2. There is a variant with discriminant 0,
3. The variant with discriminant 0 is either fieldless, or all of its fields are `Zeroable`.

Also allows using the "perfect derive with additional bounds" from #196 for Zeroable on enums, where the fields for the "perfect derive" are from the variant with discriminant 0 (see the `MyOption` example on line 189 of derive/src/lib.rs).

Internal changes:

* `VariantDiscriminantIter` now also gives the `&'a Variant` associated with the discriminant.
* the comment on line 338 of derive/src/traits.rs kept getting mangled by `cargo fmt`, so I put it on its own line.
* In `derive_marker_trait_inner`: `let predicates = ...` moved to after `let fields = ...`, since computing `fields` now requires accessing `input`, but `predicates` borrows it mutably. Does not change semantics.
* `generate_fields_are_trait` and some other helper functions now take an `Option<&Variant>` to operate on if they otherwise don't support enums.
* some `cargo fmt`
* drive-by clarification/typo fixes (e.g. renaming `discriminantor` -> `discriminant`)