### PR TITLE
Add `bytemuck` attribute to `NoUninit` derive

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -221,7 +221,7 @@ pub fn derive_zeroable(
 /// - The enum must be explicit `#[repr(Int)]`, `#[repr(C)]`, or both
 /// - All variants must be fieldless
 /// - The enum must contain no generic parameters
-#[proc_macro_derive(NoUninit)]
+#[proc_macro_derive(NoUninit, attributes(bytemuck))]
 pub fn derive_no_uninit(
   input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {


### PR DESCRIPTION
Not sure if you didn't add this attribute here for a reason, but it works perfectly for re-exporting the crate when you do

(I can also add the attribute to the other `proc_macro_derive`s if you'd like). 

