### PR TITLE
Make must_cast by-value and by-shared-ref functions const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ min_const_generics = [] # MSRV 1.51: support arrays via min_const_generics
 wasm_simd = []    # MSRV 1.54.0: support wasm simd types
 aarch64_simd = [] # MSRV 1.59.0: support aarch64 simd types
 
-must_cast = [] # MSRV 1.57.0: support the `must` module.
+must_cast = [] # MSRV 1.64.0: support the `must` module.
 
 const_zeroed = [] # MSRV 1.75.0: support const `zeroed()`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,15 @@ macro_rules! transmute {
   ($val:expr) => {
     ::core::mem::transmute_copy(&::core::mem::ManuallyDrop::new($val))
   };
+  ($srcty:ty; $dstty:ty; $val:expr) => {
+    {
+      union Transmute<A, B> {
+        src: ::core::mem::ManuallyDrop<A>,
+        dst: ::core::mem::ManuallyDrop<B>,
+      }
+      ::core::mem::ManuallyDrop::into_inner(Transmute::<$srcty, $dstty> { src: ::core::mem::ManuallyDrop::new($val) }.dst)
+    }
+  }
 }
 
 /// A macro to implement marker traits for various simd types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@ macro_rules! transmute {
   ($val:expr) => {
     ::core::mem::transmute_copy(&::core::mem::ManuallyDrop::new($val))
   };
+  // This arm is for use in const contexts, where the borrow required to use transmute_copy poses an issue
+  // since the compiler hedges that the type being borrowed could have interior mutability.
   ($srcty:ty; $dstty:ty; $val:expr) => {
     {
       union Transmute<A, B> {

--- a/src/must.rs
+++ b/src/must.rs
@@ -38,9 +38,9 @@ impl<A, B> Cast<A, B> {
 /// let bytes : [u8; 3] = bytemuck::must_cast(12_u16);
 /// ```
 #[inline]
-pub fn must_cast<A: NoUninit, B: AnyBitPattern>(a: A) -> B {
+pub const fn must_cast<A: NoUninit, B: AnyBitPattern>(a: A) -> B {
   let _ = Cast::<A, B>::ASSERT_SIZE_EQUAL;
-  unsafe { transmute!(a) }
+  unsafe { transmute!(A; B; a) }
 }
 
 /// Convert `&A` into `&B` if infalliable, or fail to compile.
@@ -64,7 +64,7 @@ pub fn must_cast<A: NoUninit, B: AnyBitPattern>(a: A) -> B {
 /// let bytes : &u16 = bytemuck::must_cast_ref(&[1u8, 2u8]);
 /// ```
 #[inline]
-pub fn must_cast_ref<A: NoUninit, B: AnyBitPattern>(a: &A) -> &B {
+pub const fn must_cast_ref<A: NoUninit, B: AnyBitPattern>(a: &A) -> &B {
   let _ = Cast::<A, B>::ASSERT_SIZE_EQUAL;
   let _ = Cast::<A, B>::ASSERT_ALIGN_GREATER_THAN_EQUAL;
   unsafe { &*(a as *const A as *const B) }
@@ -143,7 +143,7 @@ pub fn must_cast_mut<
 /// let zsts: &[()] = bytemuck::must_cast_slice(bytes);
 /// ```
 #[inline]
-pub fn must_cast_slice<A: NoUninit, B: AnyBitPattern>(a: &[A]) -> &[B] {
+pub const fn must_cast_slice<A: NoUninit, B: AnyBitPattern>(a: &[A]) -> &[B] {
   let _ = Cast::<A, B>::ASSERT_SIZE_MULTIPLE_OF_OR_INPUT_ZST;
   let _ = Cast::<A, B>::ASSERT_ALIGN_GREATER_THAN_EQUAL;
   let new_len = if size_of::<A>() == size_of::<B>() {


### PR DESCRIPTION
(but not by-mut-ref, since that's [not stable](https://github.com/rust-lang/rust/issues/57349)).

This would raise the MSRV of the `must_cast` feature from 1.57.0 to 1.64.0 (when `slice_from_raw_parts` was made const-stable). Alternately, this could be added as a new feature (`const_must_cast`?) with its own MSRV[^1]. 

The new arm of the `transmute!` macro is to work around borrowing a generic type in const-eval not being allowed on stable, since the borrowed type could have interior mutabilty. Transmuting via `union` does not have this issue, since no borrowing occurs.

[^1]: `must_cast` and `must_cast_ref`'s MSRV is at least 1.61.0, when [`const_fn_trait_bound`](https://github.com/rust-lang/rust/pull/93827/) was stabilized. `must_cast_slice`'s MSRV is at least 1.64.0, as mentioned.