### PR TITLE
Force `#[repr(C)]` layout to guarantee same offset of `union` fields.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ macro_rules! transmute {
   // since the compiler hedges that the type being borrowed could have interior mutability.
   ($srcty:ty; $dstty:ty; $val:expr) => {
     {
+      #[repr(C)]
       union Transmute<A, B> {
         src: ::core::mem::ManuallyDrop<A>,
         dst: ::core::mem::ManuallyDrop<B>,


### PR DESCRIPTION
https://rust-lang.github.io/unsafe-code-guidelines/layout/unions.html points out that

    > [...] the default layout of Rust unions is, in general,
    > unspecified.
    >
    > That is, there are no general guarantees about the offset of the
    > fields, whether all fields have the same offset, what the call ABI
    > of the union is, etc.

This commit explicitly asks for `#[repr(C)]` layout to guarantee that both fields have the same offeset.