### PR TITLE
More `TransparentWrapper` impls (`core::cmp::Reverse` and `core::num::Saturating`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ aarch64_simd = [] # MSRV 1.59.0: support aarch64 simd types
 
 must_cast = [] # MSRV 1.64.0: support the `must` module.
 
+# Adds `TransparentWrapper` impls for stdlib types newer than bytemuck's base MSRV.
+# Current MSRV 1.74.0: `core::num::Saturating`.
+# MSRV may increase if impls are added for newer types.
+transparentwrapper_extra = []
+
 const_zeroed = [] # MSRV 1.75.0: support const `zeroed()`
 
 # Do not use if you can avoid it, because this is **unsound**!!!!
@@ -66,6 +71,7 @@ features = [
   "min_const_generics",
   "wasm_simd",
   "must_cast",
+  "transparentwrapper_extra",
   "const_zeroed",
 ]
 
@@ -80,5 +86,6 @@ features = [
   "min_const_generics",
   "wasm_simd",
   "must_cast",
+  "transparentwrapper_extra",
   "const_zeroed",
 ]

--- a/src/transparent.rs
+++ b/src/transparent.rs
@@ -304,6 +304,10 @@ pub unsafe trait TransparentWrapper<Inner: ?Sized> {
 
 unsafe impl<T> TransparentWrapper<T> for core::num::Wrapping<T> {}
 #[cfg(feature = "transparentwrapper_extra")]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(feature = "transparentwrapper_extra"))
+)]
 unsafe impl<T> TransparentWrapper<T> for core::num::Saturating<T> {}
 
 // Note that `Reverse` existed since Rust 1.19.0, but was only made `#[repr(transparent)]`
@@ -311,4 +315,8 @@ unsafe impl<T> TransparentWrapper<T> for core::num::Saturating<T> {}
 // the same feature as `Saturating`, which was stabilized in Rust 1.74.0, so that this
 // impl cannot be used on a version before 1.52.0 where it would be unsound.
 #[cfg(feature = "transparentwrapper_extra")]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(feature = "transparentwrapper_extra"))
+)]
 unsafe impl<T> TransparentWrapper<T> for core::cmp::Reverse<T> {}

--- a/src/transparent.rs
+++ b/src/transparent.rs
@@ -305,4 +305,10 @@ pub unsafe trait TransparentWrapper<Inner: ?Sized> {
 unsafe impl<T> TransparentWrapper<T> for core::num::Wrapping<T> {}
 #[cfg(feature = "transparentwrapper_extra")]
 unsafe impl<T> TransparentWrapper<T> for core::num::Saturating<T> {}
+
+// Note that `Reverse` existed since Rust 1.19.0, but was only made `#[repr(transparent)]`
+// in Rust 1.52.0 (PR: https://github.com/rust-lang/rust/pull/81879), so we have it under
+// the same feature as `Saturating`, which was stabilized in Rust 1.74.0, so that this
+// impl cannot be used on a version before 1.52.0 where it would be unsound.
+#[cfg(feature = "transparentwrapper_extra")]
 unsafe impl<T> TransparentWrapper<T> for core::cmp::Reverse<T> {}

--- a/src/transparent.rs
+++ b/src/transparent.rs
@@ -303,4 +303,6 @@ pub unsafe trait TransparentWrapper<Inner: ?Sized> {
 }
 
 unsafe impl<T> TransparentWrapper<T> for core::num::Wrapping<T> {}
+#[cfg(feature = "transparentwrapper_extra")]
+unsafe impl<T> TransparentWrapper<T> for core::num::Saturating<T> {}
 unsafe impl<T> TransparentWrapper<T> for core::cmp::Reverse<T> {}

--- a/src/transparent.rs
+++ b/src/transparent.rs
@@ -303,3 +303,4 @@ pub unsafe trait TransparentWrapper<Inner: ?Sized> {
 }
 
 unsafe impl<T> TransparentWrapper<T> for core::num::Wrapping<T> {}
+unsafe impl<T> TransparentWrapper<T> for core::cmp::Reverse<T> {}


### PR DESCRIPTION
[`core::num::Saturating<T>`](https://doc.rust-lang.org/nightly/std/num/struct.Saturating.html) is `#[repr(transparent)]` and was stabilized in Rust 1.74.0, so a new cargo feature is added `transparentwrapper_extra` to hold this and other `TransparentWrapper` impls for types stabilized after Rust 1.34.0. 

[`core::cmp::Reverse<T>`](https://doc.rust-lang.org/nightly/std/cmp/struct.Reverse.html) was stabilized in Rust 1.19.0, but only gained `#[repr(transparent)]` in [Rust 1.52.0](https://github.com/rust-lang/rust/pull/81879), so it is also under the `transparentwrapper_extra` feature[^1].

cc https://github.com/Lokathor/bytemuck/issues/21

[^1]: This ensures soundness, since there is no case where `feature = "transparentwrapper_extra"` compiles on a Rust version where `Reverse` is not `#[repr(transparent)]`. Any version of Rust will either: 1. have both stable `Saturating` and `#[repr(transparent)] Reverse` (1.74.0 and above), 2. not compile `bytemuck` with the `transparentwrapper_extra` feature because `Saturating` is not stable (below 1.74.0).