### PR TITLE
Clean up Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,15 +39,6 @@ const_zeroed = [] # MSRV 1.75.0: support const `zeroed()`
 # Do not use if you can avoid it, because this is **unsound**!!!!
 unsound_ptr_pod_impl = []
 
-# NOT SEMVER SUPPORTED! TEMPORARY ONLY!
-nightly_portable_simd = []
-nightly_stdsimd = []
-# Enable `f16` and `f128`
-nightly_float = []
-
-# Improved documentation using the nightly toolchain
-nightly_docs = []
-
 # Enables all features that are both sound and supported on the latest stable
 # version of Rust, with the exception of `extern_crate_alloc` and
 # `extern_crate_std`.
@@ -65,6 +56,15 @@ latest_stable_rust = [
   "zeroable_maybe_uninit",
 ]
 
+# NOT SEMVER SUPPORTED! TEMPORARY ONLY!
+nightly_portable_simd = []
+nightly_stdsimd = []
+# Enable `f16` and `f128`
+nightly_float = []
+
+# Improved documentation using the nightly toolchain
+nightly_docs = []
+
 [dependencies]
 bytemuck_derive = { version = "1.4", path = "derive", optional = true }
 
@@ -75,27 +75,15 @@ unexpected_cfgs = { level = "deny", check-cfg = ['cfg(target_arch, values("spirv
 # Note(Lokathor): Don't use all-features or it would use `unsound_ptr_pod_impl` too.
 features = [
   "nightly_docs",
-  "derive",
+  "latest_stable_rust",
   "extern_crate_alloc",
   "extern_crate_std",
-  "zeroable_maybe_uninit",
-  "zeroable_atomics",
-  "min_const_generics",
-  "wasm_simd",
-  "must_cast",
-  "const_zeroed",
 ]
 
 [package.metadata.playground]
 # Note(Lokathor): Don't use all-features or it would use `unsound_ptr_pod_impl` too.
 features = [
-  "derive",
+  "latest_stable_rust",
   "extern_crate_alloc",
   "extern_crate_std",
-  "zeroable_maybe_uninit",
-  "zeroable_atomics",
-  "min_const_generics",
-  "wasm_simd",
-  "must_cast",
-  "const_zeroed",
 ]


### PR DESCRIPTION
- Moves `latest_stable_rust` out of the section of nightly features.
- Uses `latest_stable_rust` instead of feature list in package.metadata.