### PR TITLE
Remove incorrect spanned quote usage

### DIFF
--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -2,7 +2,7 @@
 use std::{cmp, convert::TryFrom};
 
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{quote, ToTokens};
 use syn::{
   parse::{Parse, ParseStream, Parser},
   punctuated::Punctuated,
@@ -553,7 +553,7 @@ fn get_struct_fields(input: &DeriveInput) -> Result<&Fields> {
 
 /// Extract the `Fields` off a `DeriveInput`, or, in the `enum` case, off
 /// those of the `enum_variant`, when provided (e.g., for `Zeroable`).
-/// 
+///
 /// We purposely allow not providing an `enum_variant` for cases where
 /// the caller wants to reject supporting `enum`s (e.g., `NoPadding`).
 fn get_fields(
@@ -664,7 +664,7 @@ fn generate_checked_bit_pattern_enum_without_fields(
   )?;
 
   let check = if count == 0 {
-    quote_spanned!(span => false)
+    quote!(false)
   } else if max - min == count - 1 {
     // contiguous range
     let min_lit = LitInt::new(&format!("{}", min), span);
@@ -962,22 +962,20 @@ fn generate_checked_bit_pattern_enum_with_fields(
 /// is equal to the sum of the size of it's fields
 fn generate_assert_no_padding(input: &DeriveInput) -> Result<TokenStream> {
   let struct_type = &input.ident;
-  let span = input.ident.span();
   let enum_variant = None; // `no padding` check is not supported for `enum`s yet.
   let fields = get_fields(input, enum_variant)?;
 
   let mut field_types = get_field_types(&fields);
   let size_sum = if let Some(first) = field_types.next() {
-    let size_first = quote_spanned!(span => ::core::mem::size_of::<#first>());
-    let size_rest =
-      quote_spanned!(span => #( + ::core::mem::size_of::<#field_types>() )*);
+    let size_first = quote!(::core::mem::size_of::<#first>());
+    let size_rest = quote!(#( + ::core::mem::size_of::<#field_types>() )*);
 
-    quote_spanned!(span => #size_first #size_rest)
+    quote!(#size_first #size_rest)
   } else {
-    quote_spanned!(span => 0)
+    quote!(0)
   };
 
-  Ok(quote_spanned! {span => const _: fn() = || {
+  Ok(quote! {const _: fn() = || {
     #[doc(hidden)]
     struct TypeWithoutPadding([u8; #size_sum]);
     let _ = ::core::mem::transmute::<#struct_type, TypeWithoutPadding>;
@@ -991,9 +989,8 @@ fn generate_fields_are_trait(
   let (impl_generics, _ty_generics, where_clause) =
     input.generics.split_for_impl();
   let fields = get_fields(input, enum_variant)?;
-  let span = input.span();
   let field_types = get_field_types(&fields);
-  Ok(quote_spanned! {span => #(const _: fn() = || {
+  Ok(quote! {#(const _: fn() = || {
       #[allow(clippy::missing_const_for_fn)]
       #[doc(hidden)]
       fn check #impl_generics () #where_clause {

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![deny(clippy::allow_attributes)]
 
 use bytemuck::{
   checked::CheckedCastError, AnyBitPattern, CheckedBitPattern, Contiguous,


### PR DESCRIPTION
`quote_spanned` should be used for associating `Box::new(#init)` with the `init` span, for example. This crate is associating a lot of the returned tokens with the input tokens, which breaks clippy's "are these tokens from a proc macro" checks, which leads to issues like https://github.com/rust-lang/rust-clippy/issues/13349 which are unsolvable from our end (to my knowledge).

This PR swaps with normal quote, and adds a test to make sure that none of the `allow` attributes get associated with input tokens to prevent the specific clippy issue from reappearing.