### PR TITLE
Cargo features: add `transparentwrapper_extra` to `latest_stable_rust`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ transparentwrapper_extra = []
 
 const_zeroed = [] # MSRV 1.75.0: support const `zeroed()`
 
-alloc_uninit = [] # MSRV 1.82.0: support `zeroed_*rc*`
+# MSRV 1.82.0: support `zeroed_*rc*` when combined with `extern_crate_alloc`
+alloc_uninit = []
 
 # Do not use if you can avoid it, because this is **unsound**!!!!
 unsound_ptr_pod_impl = []
@@ -69,6 +70,7 @@ latest_stable_rust = [
   "min_const_generics",
   "must_cast",
   "track_caller",
+  "transparentwrapper_extra",
   "wasm_simd",
   "zeroable_atomics",
   "zeroable_maybe_uninit",

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -438,7 +438,7 @@ pub fn from_bytes_mut<T: NoUninit + CheckedBitPattern>(s: &mut [u8]) -> &mut T {
 /// Reads the slice into a `T` value.
 ///
 /// ## Panics
-/// * This is like `try_pod_read_unaligned` but will panic on failure.
+/// * This is like [`try_pod_read_unaligned`] but will panic on failure.
 #[inline]
 #[cfg_attr(feature = "track_caller", track_caller)]
 pub fn pod_read_unaligned<T: CheckedBitPattern>(bytes: &[u8]) -> T {


### PR DESCRIPTION
Also expands on the comment for `alloc_uninit`, saying that it doesn't do anything if `extern_crate_alloc` is not also enabled.

Also adds an intra-doc link to `src/checked.rs`.

May close #288 