### PR TITLE
fix deriving CheckedBitpattern on packed struct

### DIFF
--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -623,7 +623,7 @@ fn generate_checked_bit_pattern_struct(
           impl ::core::fmt::Debug for #bits_ty {
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
               let mut debug_struct = ::core::fmt::Formatter::debug_struct(f, ::core::stringify!(#bits_ty));
-              #(::core::fmt::DebugStruct::field(&mut debug_struct, ::core::stringify!(#field_name), &self.#field_name);)*
+              #(::core::fmt::DebugStruct::field(&mut debug_struct, ::core::stringify!(#field_name), &{ self.#field_name });)*
               ::core::fmt::DebugStruct::finish(&mut debug_struct)
             }
           }

--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -214,6 +214,13 @@ struct CheckedBitPatternAlignedStruct {
   a: u16,
 }
 
+#[derive(Clone, Copy, CheckedBitPattern)]
+#[repr(C, packed)]
+struct CheckedBitPatternPackedStruct {
+  a: u8,
+  b: u16,
+}
+
 #[derive(Debug, Clone, Copy, CheckedBitPattern, PartialEq, Eq)]
 #[repr(C)]
 enum CheckedBitPatternCDefaultDiscriminantEnumWithFields {


### PR DESCRIPTION
This PR fixes the code emitted by the `CheckedBitPattern` derive macro to make it compatible with packed structs. It also adds a regression test for this.