### PR TITLE
Implement Send and Sync for BoxBytes.

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -783,6 +783,12 @@ pub struct BoxBytes {
   layout: Layout,
 }
 
+// SAFETY: `BoxBytes` is semantically a `Box<[u8], Global>` with a different allocation alignment,
+// `Box<[u8], Global>` is `Send + Sync`, and changing the allocation alignment has no thread-safety implications.
+unsafe impl Send for BoxBytes {}
+// SAFETY: See `Send` impl
+unsafe impl Sync for BoxBytes {}
+
 impl Deref for BoxBytes {
   type Target = [u8];
 


### PR DESCRIPTION
Fixes #298 

-----

Semi-related: it might also make sense to implement other traits for `BoxBytes` (`Borrow(Mut)<[u8]>`/`Hash`/`As(Ref|Mut)<[u8]>`/`Ord` by delegating to `[u8]`, maybe `Default`). Not sure how useful those would be in practice though.