### PR TITLE
bump bytemuck_derive dependency to >= 1.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ nightly_float = []
 nightly_docs = []
 
 [dependencies]
-bytemuck_derive = { version = "1.4", path = "derive", optional = true }
+bytemuck_derive = { version = "1.4.1", path = "derive", optional = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = ['cfg(target_arch, values("spirv"))'] }


### PR DESCRIPTION
Derived traits on structs with generic parameters is broken in bytemuck_derive 1.4.0 (#168), which can cause builds to fail in confusing ways.

Fixes #300.