### PR TITLE
Add `pod_saturating` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ unsound_ptr_pod_impl = []
 # MSRV 1.46.0: adds the `#[track_caller]` attribute to functions which may panic
 track_caller = []
 
+# MSRV 1.74.0 Pod/Zeroable implementations for `core::num::Saturating`
+pod_saturating = []
+
 # Enables all features that are both sound and supported on the latest stable
 # version of Rust, with the exception of `extern_crate_alloc` and
 # `extern_crate_std`.
@@ -73,6 +76,7 @@ latest_stable_rust = [
   "min_const_generics",
   "must_cast",
   "must_cast_extra",
+  "pod_saturating",
   "track_caller",
   "transparentwrapper_extra",
   "wasm_simd",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@
 //!   Box and Vec.
 //! * `zeroable_maybe_uninit` and `zeroable_atomics`: Provide more [`Zeroable`]
 //!   impls.
+//! * `pod_saturating`: Provide more [`Pod`] and [`Zeroable`] impls.
 //! * `wasm_simd` and `aarch64_simd`: Support more SIMD types.
 //! * `min_const_generics`: Provides appropriate impls for arrays of all lengths
 //!   instead of just for a select list of array lengths.

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -57,6 +57,9 @@ unsafe impl Pod for f64 {}
 unsafe impl Pod for f128 {}
 unsafe impl<T: Pod> Pod for Wrapping<T> {}
 
+#[cfg(feature = "pod_saturating")]
+unsafe impl<T: Pod> Pod for core::num::Saturating<T>{}
+
 #[cfg(feature = "unsound_ptr_pod_impl")]
 #[cfg_attr(
   feature = "nightly_docs",

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -56,6 +56,8 @@ unsafe impl Zeroable for f64 {}
 unsafe impl Zeroable for f128 {}
 unsafe impl<T: Zeroable> Zeroable for Wrapping<T> {}
 unsafe impl<T: Zeroable> Zeroable for core::cmp::Reverse<T> {}
+#[cfg(feature = "pod_saturating")]
+unsafe impl<T: Zeroable> Zeroable for core::num::Saturating<T> {}
 
 // Note: we can't implement this for all `T: ?Sized` types because it would
 // create NULL pointers for vtables.


### PR DESCRIPTION
This adds the `pod_saturating` feature (requires MSRV 1.74) and `Pod`/`Zeroable` impls for `core::num::Saturating<T>` when the feature is enabled.