### PR TITLE
Remove rust-version and resolver from derive/Cargo.toml

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bytemuck_derive"
 description = "derive proc-macros for `bytemuck`"
-version = "1.9.1"
+version = "1.9.2"
 authors = ["Lokathor <zefria@gmail.com>"]
 repository = "https://github.com/Lokathor/bytemuck"
 readme = "README.md"
@@ -9,8 +9,6 @@ keywords = ["transmute", "bytes", "casting"]
 categories = ["encoding", "no-std"]
 edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
-rust-version = "1.84"
-resolver = "3"
 
 [lib]
 name = "bytemuck_derive"


### PR DESCRIPTION
This fixes #306, and bumps the version.

The root cause is a bit of a SNAFU: `bytemuck` specifies a version dependency of `1.4.1` on `bytemuck_derive`, which should be checked and fetched. Since this expands to `>=1.4.1, <2.0.0`, it happily accepts `1.9.1` even if it can't be compiled with a less than 6 month old compiler version.

```
Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized
 in this version of Cargo (1.81.0 (2dbb1af80 2024-08-20)).
```

By removing these fields which are non-essential (as of yet), we retain backwards compatibility. Once we *require* a later version of Rust, we can add these fields accordingly, and bump the major version so that an older, backwards compatible package is chosen.