### PR TITLE
Extend #308 with `-unwind` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ track_caller = []
 # MSRV 1.74.0 Pod/Zeroable implementations for `core::num::Saturating`
 pod_saturating = []
 
+# MSRV 1.71: Adds ZeroableInOption impl for fn-ptrs with -unwind
+zeroable_unwind_fn = []
+
 # Enables all features that are both sound and supported on the latest stable
 # version of Rust, with the exception of `extern_crate_alloc` and
 # `extern_crate_std`.
@@ -82,6 +85,7 @@ latest_stable_rust = [
   "wasm_simd",
   "zeroable_atomics",
   "zeroable_maybe_uninit",
+  "zeroable_unwind_fn",
 ]
 
 # ALL FEATURES BELOW THIS ARE NOT SEMVER SUPPORTED! TEMPORARY ONLY!

--- a/src/zeroable_in_option.rs
+++ b/src/zeroable_in_option.rs
@@ -42,6 +42,15 @@ macro_rules! impl_for_fn {
         unsafe impl<$($ArgTy,)* R> ZeroableInOption for unsafe extern "C" fn($($ArgTy,)*) -> R {}
         unsafe impl<$($ArgTy,)* R> ZeroableInOption for extern "system" fn($($ArgTy,)*) -> R {}
         unsafe impl<$($ArgTy,)* R> ZeroableInOption for unsafe extern "system" fn($($ArgTy,)*) -> R {}
+
+        #[cfg(feature = "zeroable_unwind_fn")]
+        unsafe impl<$($ArgTy,)* R> ZeroableInOption for extern "C-unwind" fn($($ArgTy,)*) -> R {}
+        #[cfg(feature = "zeroable_unwind_fn")]
+        unsafe impl<$($ArgTy,)* R> ZeroableInOption for unsafe extern "C-unwind" fn($($ArgTy,)*) -> R {}
+        #[cfg(feature = "zeroable_unwind_fn")]
+        unsafe impl<$($ArgTy,)* R> ZeroableInOption for extern "system-unwind" fn($($ArgTy,)*) -> R {}
+        #[cfg(feature = "zeroable_unwind_fn")]
+        unsafe impl<$($ArgTy,)* R> ZeroableInOption for unsafe extern "system-unwind" fn($($ArgTy,)*) -> R {}
     };
 }
 

--- a/src/zeroable_in_option.rs
+++ b/src/zeroable_in_option.rs
@@ -34,6 +34,16 @@ unsafe impl<T: ?Sized> ZeroableInOption for &'_ mut T {}
 #[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "extern_crate_alloc")))]
 unsafe impl<T: ?Sized> ZeroableInOption for alloc::boxed::Box<T> {}
 
+#[cfg(feature = "zeroable_unwind_fn")]
+macro_rules! impl_for_unwind_fn {
+    ($($ArgTy:ident),* $(,)?) => {
+        unsafe impl<$($ArgTy,)* R> ZeroableInOption for extern "C-unwind" fn($($ArgTy,)*) -> R {}
+        unsafe impl<$($ArgTy,)* R> ZeroableInOption for unsafe extern "C-unwind" fn($($ArgTy,)*) -> R {}
+        unsafe impl<$($ArgTy,)* R> ZeroableInOption for extern "system-unwind" fn($($ArgTy,)*) -> R {}
+        unsafe impl<$($ArgTy,)* R> ZeroableInOption for unsafe extern "system-unwind" fn($($ArgTy,)*) -> R {}
+    };
+}
+
 macro_rules! impl_for_fn {
     ($($ArgTy:ident),* $(,)?) => {
         unsafe impl<$($ArgTy,)* R> ZeroableInOption for fn($($ArgTy,)*) -> R {}
@@ -42,17 +52,12 @@ macro_rules! impl_for_fn {
         unsafe impl<$($ArgTy,)* R> ZeroableInOption for unsafe extern "C" fn($($ArgTy,)*) -> R {}
         unsafe impl<$($ArgTy,)* R> ZeroableInOption for extern "system" fn($($ArgTy,)*) -> R {}
         unsafe impl<$($ArgTy,)* R> ZeroableInOption for unsafe extern "system" fn($($ArgTy,)*) -> R {}
-
         #[cfg(feature = "zeroable_unwind_fn")]
-        unsafe impl<$($ArgTy,)* R> ZeroableInOption for extern "C-unwind" fn($($ArgTy,)*) -> R {}
-        #[cfg(feature = "zeroable_unwind_fn")]
-        unsafe impl<$($ArgTy,)* R> ZeroableInOption for unsafe extern "C-unwind" fn($($ArgTy,)*) -> R {}
-        #[cfg(feature = "zeroable_unwind_fn")]
-        unsafe impl<$($ArgTy,)* R> ZeroableInOption for extern "system-unwind" fn($($ArgTy,)*) -> R {}
-        #[cfg(feature = "zeroable_unwind_fn")]
-        unsafe impl<$($ArgTy,)* R> ZeroableInOption for unsafe extern "system-unwind" fn($($ArgTy,)*) -> R {}
+        impl_for_unwind_fn!($($ArgTy),*);
     };
 }
+
+
 
 impl_for_fn!();
 impl_for_fn!(A);


### PR DESCRIPTION
Adding to #308, this adds `C-unwind` and `system-unwind` fn-ptr `ZeroableInPod` impls behind the `zeroable_unwind_fn` feature gate.