### PR TITLE
Set rust version for `bytemuck_derive` to 1.61

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ jobs:
         include:
         # versions (all on linux-x86_64)
         - { rust: 1.34.0, os: ubuntu-latest }
+        - { rust: 1.61.0, os: ubuntu-latest }
         - { rust: stable, os: ubuntu-latest }
         - { rust: beta, os: ubuntu-latest }
         - { rust: nightly, os: ubuntu-latest }
@@ -36,6 +37,8 @@ jobs:
     - run: cargo test --verbose
     - run: cargo test --verbose --no-default-features
     - run: cargo test --verbose
+    - run: cargo test --verbose --features derive
+      if: matrix.rust == '1.61.0'
     - run: cargo test --verbose --all-features
       if: matrix.rust == 'nightly'
     - run: cargo test --verbose --manifest-path=derive/Cargo.toml --all-features

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bytemuck_derive"
 description = "derive proc-macros for `bytemuck`"
-version = "1.9.2"
+version = "1.9.3"
 authors = ["Lokathor <zefria@gmail.com>"]
 repository = "https://github.com/Lokathor/bytemuck"
 readme = "README.md"
@@ -9,7 +9,7 @@ keywords = ["transmute", "bytes", "casting"]
 categories = ["encoding", "no-std"]
 edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
-rust-version = "1.84"
+rust-version = "1.61"
 #note(lokathor): do not publish with this set
 #resolver = "3"
 


### PR DESCRIPTION
~~https://github.com/Lokathor/bytemuck/pull/293/commits/7ae54e291b8b3d4a89ee4a199ae693412cb6b50f sets the edition to `2018` so that bytemuck_derive can build with Rust `1.34`.~~ `bytemuck_derive` will build with Rust `1.61`,  however, the `rust-version` field in `Cargo.toml` is set to `1.84` not `1.61`. We should set the version to `1.61` so that users with older rust versions can compile the crate.