### PR TITLE
Impl core's Error trait on Rust 1.81+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ pod_saturating = []
 # MSRV 1.71: Adds ZeroableInOption impl for fn-ptrs with -unwind
 zeroable_unwind_fn = []
 
+# MSRV 1.81: Impls core::error:Error for error types
+impl_core_error = []
+
 # Enables all features that are both sound and supported on the latest stable
 # version of Rust, with the exception of `extern_crate_alloc` and
 # `extern_crate_std`.
@@ -76,6 +79,7 @@ latest_stable_rust = [
   "alloc_uninit",
   "const_zeroed",
   "derive",
+  "impl_core_error",
   "min_const_generics",
   "must_cast",
   "must_cast_extra",

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -228,6 +228,10 @@ impl core::fmt::Display for CheckedCastError {
 #[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "extern_crate_std")))]
 impl std::error::Error for CheckedCastError {}
 
+// Rust 1.81+
+#[cfg(all(feature = "impl_core_error", not(feature = "extern_crate_std")))]
+impl core::error::Error for CheckedCastError {}
+
 impl From<crate::PodCastError> for CheckedCastError {
   fn from(err: crate::PodCastError) -> CheckedCastError {
     CheckedCastError::PodCastError(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,10 @@ impl core::fmt::Display for PodCastError {
 #[cfg_attr(feature = "nightly_docs", doc(cfg(feature = "extern_crate_std")))]
 impl std::error::Error for PodCastError {}
 
+// Rust 1.81+
+#[cfg(all(feature = "impl_core_error", not(feature = "extern_crate_std")))]
+impl core::error::Error for PodCastError {}
+
 /// Re-interprets `&T` as `&[u8]`.
 ///
 /// Any ZST becomes an empty slice, and in that case the pointer value of that


### PR DESCRIPTION
Hello awesome bytemuck devs!

Rust's `Error` trait is available in `core` as of 1.81. This small patch adds a crate feature to derive [core::error::Error](https://doc.rust-lang.org/nightly/core/error/trait.Error.html) instead of bringing in `std`.

I added an extra feature instead of changing the original derive so that it doesn't affect users on older Rust versions. I also accounted for the case when both features are enabled for some reason.