### PR TITLE
impl `AnyBitPattern` for `[MaybeUninit<T: AnyBitPattern>; N]`

### DIFF
--- a/src/anybitpattern.rs
+++ b/src/anybitpattern.rs
@@ -62,3 +62,16 @@ unsafe impl<T: Pod> AnyBitPattern for T {}
 )]
 unsafe impl<T> AnyBitPattern for core::mem::MaybeUninit<T> where T: AnyBitPattern
 {}
+
+#[cfg(all(feature = "zeroable_maybe_uninit", feature = "min_const_generics"))]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(all(
+    feature = "zeroable_maybe_uninit",
+    feature = "min_const_generics"
+  )))
+)]
+unsafe impl<T, const N: usize> AnyBitPattern for [core::mem::MaybeUninit<T>; N] where
+  T: AnyBitPattern
+{
+}


### PR DESCRIPTION
Provides the following implementation:

```rust
#[cfg(all(feature = "zeroable_maybe_uninit", feature = "min_const_generics"))]
#[cfg_attr(
  feature = "nightly_docs",
  doc(cfg(all(
    feature = "zeroable_maybe_uninit",
    feature = "min_const_generics"
  )))
)]
unsafe impl<T, const N: usize> AnyBitPattern for [core::mem::MaybeUninit<T>; N] where
  T: AnyBitPattern
{
}
```

Which allows arrays of `MaybeUninit<T: AnyBitPattern>` to be treated as `AnyBitPattern`. For instance, the following struct is not currently possible via the safer derive macro for `AnyBitPattern`:

```rust
#[repr(align(0x10))]
#[derive(AnyBitPattern)]
struct Stack<const N: usize>([MaybeUninit<u8>; N]);
```

Which results in the following error on the struct's tuple field:
```
the trait bound `core::mem::MaybeUninit<u8>: bytemuck::Pod` is not satisfied
```

... which complicates my current use case, of trying to safely allocate a `Stack` of uninitialized bytes (skipping the cost of first zeroing the stack, which isn't required for a process stack).