### PR TITLE
Make the `Pod`/`NoUninit` derive macros more robust against possible future relaxations of `std::mem::transmute`'s semantics.

### DIFF
--- a/derive/src/traits.rs
+++ b/derive/src/traits.rs
@@ -1073,10 +1073,23 @@ fn generate_assert_no_padding(
     quote!(0)
   };
 
-  Ok(quote! {const _: fn() = || {
+  // We are using `transmute` to check that the size of the type is equal to the sum of the
+  // sizes of its fields, which may in the future require actually evaluating a transmute
+  // to emit an error, so we emit a free unnamed constant item that performs a transmute of
+  // `MaybeUninit`s to be maximally forward compatible with possible relaxations of
+  // `transmute`'s requirements.
+  Ok(quote! {const _: () = {
     #[doc(hidden)]
+    #[repr(transparent)]
     struct TypeWithoutPadding([u8; #size_sum]);
-    let _ = ::core::mem::transmute::<#struct_type, TypeWithoutPadding>;
+
+    // SAFETY: `MaybeUninit` has no validity invariants, it is always sound to transmute to.
+    let _ = unsafe {
+        ::core::mem::transmute::<
+            ::core::mem::MaybeUninit<#struct_type>,
+            ::core::mem::MaybeUninit<TypeWithoutPadding>,
+        >(::core::mem::MaybeUninit::uninit())
+    };
   };})
 }
 


### PR DESCRIPTION
[RFC 3844](https://github.com/rust-lang/rfcs/pull/3844) is proposing relaxations to `std::mem::transmute`'s semantics, and under some possible relaxations, `bytemuck_derive`'s current usage of it to ensure soundness becomes insufficient[^1].

This PR makes the `Pod`/`NoUninit` derive macros forward-compatible with some possible relaxations of `transmute`'s semantics.


Concrete change: For the following source code:

```Rust
#[repr(C)]
#[derive(Clone, Copy, Debug, bytemuck::Zeroable, bytemuck::Pod)]
pub struct Foo(u32, u32);
```

The `Pod` (and `NoUninit`) derive macros' no-padding check is changed from:

```Rust
const _: fn() = || {
    #[doc(hidden)]
    struct TypeWithoutPadding(
        [u8; ::core::mem::size_of::<u32>() + ::core::mem::size_of::<u32>()],
    );
    let _ = ::core::mem::transmute::<Foo, TypeWithoutPadding>;
};

```

To this:

```Rust
const _: () = {
    #[doc(hidden)]
    #[repr(transparent)]
    struct TypeWithoutPadding(
        [u8; ::core::mem::size_of::<u32>() + ::core::mem::size_of::<u32>()],
    );
    let _ = unsafe {
        ::core::mem::transmute::<
            ::core::mem::MaybeUninit<Foo>,
            ::core::mem::MaybeUninit<TypeWithoutPadding>,
        >(::core::mem::MaybeUninit::uninit())
    };
};
```

(Adding `#[repr(transprent)]` is not relevant to the RFC's changes, that's just a drive-by fix)

The error message when applying the derive macros to invalid structs is *slightly* worse (it wraps the "source" and "target" types in `MaybeUninit`, which makes sense but could be confusing to users), but IMO not significantly so.

<details><summary>error message change</summary>

```Rust
// src/lib.rs
#[repr(C)]
#[derive(Clone, Copy, Debug, bytemuck::Zeroable, bytemuck::Pod)]
pub struct Foo(u32, u16);

// old error
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
 --> src/lib.rs:2:50
  |
2 | #[derive(Clone, Copy, Debug, bytemuck::Zeroable, bytemuck::Pod)]
  |                                                  ^^^^^^^^^^^^^
  |
  = note: source type: `Foo` (64 bits)
  = note: target type: `TypeWithoutPadding` (48 bits)
  = note: this error originates in the derive macro `bytemuck::Pod` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0512`.

// new error
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
 --> src/lib.rs:2:50
  |
2 | #[derive(Clone, Copy, Debug, bytemuck::Zeroable, bytemuck::Pod)]
  |                                                  ^^^^^^^^^^^^^
  |
  = note: source type: `MaybeUninit<Foo>` (64 bits)
  = note: target type: `MaybeUninit<TypeWithoutPadding>` (48 bits)
  = note: this error originates in the derive macro `bytemuck::Pod` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0512`.
```

</details>

-----

We could also instead emit something like `const _: () = assert!(::core::mem::size_of::<Foo>() == (#size_sum), "type has padding when it shouldn't");` instead of using `transmute`, which would emit a `evaluation of constant value failed` error where we can add our own context, but cannot do string formatting since it's in a `const` context.

```Rust
// expansion
const _: () = {
    assert!(
        ::core::mem::size_of::<Foo>() == (::core::mem::size_of::<u32>() + ::core::mem::size_of::<u16>()),
        "derive(bytemuck::Pod) or derive(bytemuck::NoUninit) was applied to a type with padding",
    );
};


// error for Foo(u32, u16)
error[E0080]: evaluation of constant value failed
 --> src/lib.rs:2:50
  |
2 | #[derive(Clone, Copy, Debug, bytemuck::Zeroable, bytemuck::Pod)]
  |                                                  ^^^^^^^^^^^^^ evaluation panicked: derive(bytemuck::Pod) or derive(bytemuck::NoUninit) was applied to a type with padding

For more information about this error, try `rustc --explain E0080`.
```

[^1]: Currently, the derive macros only *mention* `std::mem::transmute::<Foo, FooWithoutPadding>`, they don't *call* it, and under at least the proposed "just have a `const` assert that the sizes are the same in the body of `transmute`" change, this would no longer be enough to ensure a compiler error if `Type1` and `Type2` have different sizes: [playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=fb5e5f0ab285e8907db61d17d5bba9fe)