### PR TITLE
chore: use new stable avx512 types from rust 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ min_const_generics = [] # MSRV 1.51: support arrays via min_const_generics
 
 wasm_simd = []    # MSRV 1.54.0: support wasm simd types
 aarch64_simd = [] # MSRV 1.59.0: support aarch64 simd types
-avx512_simd = [] # MSRV 1.72.0: support avx512 simd types
+avx512_simd = []  # MSRV 1.89.0: support avx512 simd types
 
 must_cast = [] # MSRV 1.64.0: support the `must` module.
 must_cast_extra = ["must_cast"] # MSRV 1.83.0: support mutable references in const

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,6 @@
 #![cfg_attr(feature = "nightly_docs", feature(doc_cfg))]
 #![cfg_attr(feature = "nightly_portable_simd", feature(portable_simd))]
 #![cfg_attr(feature = "nightly_float", feature(f16, f128))]
-#![cfg_attr(
-  all(
-    feature = "nightly_stdsimd",
-    any(target_arch = "x86_64", target_arch = "x86")
-  ),
-  feature(stdarch_x86_avx512)
-)]
 
 //! This crate gives small utilities for casting between plain data types.
 //!

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -170,14 +170,14 @@ impl_unsafe_marker_for_simd!(
 );
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+  #[cfg(all(target_arch = "x86", feature = "nightly_stdsimd", feature = "avx512_simd"))]
   unsafe impl Pod for x86::{
     __m128bh, __m256bh, __m512bh
   }
 );
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+  #[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd", feature = "avx512_simd"))]
   unsafe impl Pod for x86_64::{
     __m128bh, __m256bh, __m512bh
   }

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -156,28 +156,28 @@ where
 }
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86", any(feature = "nightly_stdsimd", feature = "avx512_simd")))]
+  #[cfg(all(target_arch = "x86", feature = "avx512_simd"))]
   unsafe impl Pod for x86::{
     __m512, __m512d, __m512i
   }
 );
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86_64", any(feature = "nightly_stdsimd", feature = "avx512_simd")))]
+  #[cfg(all(target_arch = "x86_64", feature = "avx512_simd"))]
   unsafe impl Pod for x86_64::{
     __m512, __m512d, __m512i
   }
 );
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86", feature = "nightly_stdsimd", feature = "avx512_simd"))]
+    #[cfg(all(target_arch = "x86", feature = "avx512_simd"))]
   unsafe impl Pod for x86::{
     __m128bh, __m256bh, __m512bh
   }
 );
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd", feature = "avx512_simd"))]
+    #[cfg(all(target_arch = "x86_64", feature = "avx512_simd"))]
   unsafe impl Pod for x86_64::{
     __m128bh, __m256bh, __m512bh
   }

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -249,14 +249,14 @@ impl_unsafe_marker_for_simd!(
 );
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86", feature = "nightly_stdsimd"))]
+  #[cfg(all(target_arch = "x86", any(feature = "nightly_stdsimd", feature = "avx512_simd")))]
   unsafe impl Zeroable for x86::{
     __m128bh, __m256bh, __m512bh
   }
 );
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86_64", feature = "nightly_stdsimd"))]
+  #[cfg(all(target_arch = "x86_64", any(feature = "nightly_stdsimd", feature = "avx512_simd")))]
   unsafe impl Zeroable for x86_64::{
     __m128bh, __m256bh, __m512bh
   }

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -235,28 +235,28 @@ where
 }
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86", any(feature = "nightly_stdsimd", feature = "avx512_simd")))]
+  #[cfg(all(target_arch = "x86", feature = "avx512_simd"))]
   unsafe impl Zeroable for x86::{
     __m512, __m512d, __m512i
   }
 );
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86_64", any(feature = "nightly_stdsimd", feature = "avx512_simd")))]
+  #[cfg(all(target_arch = "x86_64", feature = "avx512_simd"))]
   unsafe impl Zeroable for x86_64::{
     __m512, __m512d, __m512i
   }
 );
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86", any(feature = "nightly_stdsimd", feature = "avx512_simd")))]
+  #[cfg(all(target_arch = "x86",  feature = "avx512_simd"))]
   unsafe impl Zeroable for x86::{
     __m128bh, __m256bh, __m512bh
   }
 );
 
 impl_unsafe_marker_for_simd!(
-  #[cfg(all(target_arch = "x86_64", any(feature = "nightly_stdsimd", feature = "avx512_simd")))]
+  #[cfg(all(target_arch = "x86_64", feature = "avx512_simd"))]
   unsafe impl Zeroable for x86_64::{
     __m128bh, __m256bh, __m512bh
   }


### PR DESCRIPTION
With the release of rust 1.89, `stdarch_x86_avx512` has been stabilized and do not need the use of a nightly toolchain.
This PR adds support for these types in the `avx512_simd` feature. 

The `nightly_stdsimd` feature has been kept for backward compatibility but I can remove it if you prefer.