### PR TITLE
Fix 32bit tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
         include:
         # versions (all on linux-x86_64)
         - { rust: 1.34.0, os: ubuntu-latest }
-        - { rust: 1.61.0, os: ubuntu-latest }
+        - { rust: 1.68.0, os: ubuntu-latest }
         - { rust: stable, os: ubuntu-latest }
         - { rust: beta, os: ubuntu-latest }
         - { rust: nightly, os: ubuntu-latest }
@@ -38,7 +38,7 @@ jobs:
     - run: cargo test --verbose --no-default-features
     - run: cargo test --verbose
     - run: cargo test --verbose --features derive
-      if: matrix.rust == '1.61.0'
+      if: matrix.rust == '1.68.0'
     - run: cargo test --verbose --all-features
       if: matrix.rust == 'nightly'
     - run: cargo test --verbose --manifest-path=derive/Cargo.toml --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ exclude = ["/pedantic.bat", "derive/", "contiguous_bitset/"]
 [features]
 # In v2 we'll fix these names to be more "normal".
 
-# Enable deriving the various `bytemuck` traits.
+# All MSRV notes below are GUIDELINES and future versions may require even more
+# MSRV on any feature.
+
+# MSRV 1.68.0: Enable deriving the various `bytemuck` traits.
 derive = ["bytemuck_derive"]
 # Enable features requiring items from `extern crate alloc`.
 extern_crate_alloc = []
@@ -24,9 +27,6 @@ extern_crate_std = ["extern_crate_alloc"]
 zeroable_maybe_uninit = []
 # Implement `Zeroable` for `std::sync::atomic` types.
 zeroable_atomics = []
-
-# All MSRV notes below are GUIDELINES and future versions may require even more
-# MSRV on any feature.
 
 # MSRV 1.36: Use `align_offset` method instead of casting to `usize` to check
 # alignment of pointers, this *may* improve codegen in some cases (but it has

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["transmute", "bytes", "casting"]
 categories = ["encoding", "no-std"]
 edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
-rust-version = "1.61"
+rust-version = "1.68"
 #note(lokathor): do not publish with this set
 #resolver = "3"
 

--- a/tests/std_tests.rs
+++ b/tests/std_tests.rs
@@ -58,7 +58,7 @@ fn test_try_from_box_bytes() {
 
   // Different layout: target alignment is less than source alignment.
   assert_eq!(
-    try_from_box_bytes::<u32>(Box::new(0u64).into()).map_err(|(x, _)| x),
+    try_from_box_bytes::<u16>(Box::new(0u64).into()).map_err(|(x, _)| x),
     Err(PodCastError::AlignmentMismatch)
   );
 


### PR DESCRIPTION
Fixes #330 for i686-unknown-linux-gnu, not sure about s390x.

Also addresses a test failure for `try_from_box_bytes` on i686-unknown-linux-gnu (the conversion was intended to fail with AlignmentMismatch, but failed with SizeMismatch because `u32` and `u64` have the same alignment on that target)