### PR TITLE
Make derive(NoUninit) have the same constraints as Pod

### DIFF
--- a/derive/tests/basic.rs
+++ b/derive/tests/basic.rs
@@ -229,6 +229,16 @@ enum NoUninitEnumWithFieldsAndDiscriminant {
   B(u8, u8, u8, u8),
 }
 
+#[derive(Copy, Clone, NoUninit)]
+#[repr(transparent)]
+struct NoUninitTransparentWrapper<T: NoUninit>(T);
+
+impl<T: NoUninit> NoUninitTransparentWrapper<T> {
+  fn new(value: T) -> Self {
+    Self(value)
+  }
+}
+
 #[derive(Debug, Copy, Clone, AnyBitPattern, PartialEq, Eq)]
 #[repr(C)]
 struct AnyBitPatternTest<A: AnyBitPattern, B: AnyBitPattern> {

--- a/derive/tests/transparent_wrapper_generic.rs
+++ b/derive/tests/transparent_wrapper_generic.rs
@@ -1,0 +1,29 @@
+use bytemuck;
+
+#[derive(Copy, Clone, bytemuck::NoUninit)]
+#[repr(transparent)]
+struct TransparentWrapper<T: bytemuck::NoUninit>(T);
+
+#[derive(Copy, Clone, bytemuck::NoUninit)]
+#[repr(packed(1))]
+struct PackedWrapper<T: bytemuck::NoUninit> {
+    value: T,
+}
+
+#[test]
+fn test_nouninit_transparent_wrapper() {
+    // This test just needs to compile to verify that NoUninit can be derived
+    // for repr(transparent) generic types
+    let w = TransparentWrapper(42u32);
+    assert_eq!(w.0, 42);
+}
+
+#[test]
+fn test_nouninit_packed_wrapper() {
+    // This test just needs to compile to verify that NoUninit can be derived
+    // for repr(packed(1)) generic types
+    let w = PackedWrapper { value: 42u32 };
+    // Read value to avoid unaligned reference warning
+    let value = { w.value };
+    assert_eq!(value, 42);
+}


### PR DESCRIPTION
Derive is allowed for generic types if they are `repr(transparent)` or `packed(1)`.

Also fixes the `completly_packed` typo because I didn't want to copy it and I didn't want the cases to be inconsistent.

Fixes #340 