### PR TITLE
Fix `nightly_portable_simd` after `LaneCount` removal.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ latest_stable_rust = [
 # ALL FEATURES BELOW THIS ARE NOT SEMVER SUPPORTED! TEMPORARY ONLY!
 
 # Enable support for `std::simd` types.
-nightly_portable_simd = []
+nightly_portable_simd = ["rustversion"]
 # Enable support for unstable `std::arch` types (such as the AVX512 types).
 nightly_stdsimd = []
 # Enable `f16` and `f128`
@@ -108,6 +108,7 @@ nightly_docs = []
 
 [dependencies]
 bytemuck_derive = { version = "1.10.2", path = "derive", optional = true }
+rustversion = { version = "1.0.22", optional = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = [

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -143,6 +143,7 @@ impl_unsafe_marker_for_simd!(
   }
 );
 
+#[rustversion::before(2026-01-27)] // See https://github.com/Lokathor/bytemuck/issues/343
 #[cfg(feature = "nightly_portable_simd")]
 #[cfg_attr(
   feature = "nightly_docs",
@@ -152,6 +153,18 @@ unsafe impl<T, const N: usize> Pod for core::simd::Simd<T, N>
 where
   T: core::simd::SimdElement + Pod,
   core::simd::LaneCount<N>: core::simd::SupportedLaneCount,
+{
+}
+
+#[rustversion::since(2026-01-27)] // See https://github.com/Lokathor/bytemuck/issues/343
+#[cfg(feature = "nightly_portable_simd")]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(feature = "nightly_portable_simd"))
+)]
+unsafe impl<T, const N: usize> Pod for core::simd::Simd<T, N>
+where
+  T: core::simd::SimdElement + Pod,
 {
 }
 

--- a/src/zeroable.rs
+++ b/src/zeroable.rs
@@ -222,6 +222,7 @@ impl_unsafe_marker_for_simd!(
     }
 );
 
+#[rustversion::before(2026-01-27)] // See https://github.com/Lokathor/bytemuck/issues/343
 #[cfg(feature = "nightly_portable_simd")]
 #[cfg_attr(
   feature = "nightly_docs",
@@ -231,6 +232,18 @@ unsafe impl<T, const N: usize> Zeroable for core::simd::Simd<T, N>
 where
   T: core::simd::SimdElement + Zeroable,
   core::simd::LaneCount<N>: core::simd::SupportedLaneCount,
+{
+}
+
+#[rustversion::since(2026-01-27)] // See https://github.com/Lokathor/bytemuck/issues/343
+#[cfg(feature = "nightly_portable_simd")]
+#[cfg_attr(
+  feature = "nightly_docs",
+  doc(cfg(feature = "nightly_portable_simd"))
+)]
+unsafe impl<T, const N: usize> Zeroable for core::simd::Simd<T, N>
+where
+  T: core::simd::SimdElement + Zeroable,
 {
 }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/commit/0eaef592336f0c12cd9648c989f360308d842d2d (which included https://github.com/rust-lang/portable-simd/pull/485) was merged on 2026-01-27 and removed `core::simd::LaneCount`.  This `bytemuck` commit ensures that `nightly_portable_simd` feature of `bytemuck` can build with nightly Rust before and after the `LaneCount` change.

Fixes https://github.com/Lokathor/bytemuck/issues/343