### PR TITLE
Don't impl core::error::Error on spirv

### DIFF
--- a/src/checked.rs
+++ b/src/checked.rs
@@ -229,7 +229,11 @@ impl core::fmt::Display for CheckedCastError {
 impl std::error::Error for CheckedCastError {}
 
 // Rust 1.81+
-#[cfg(all(feature = "impl_core_error", not(feature = "extern_crate_std")))]
+#[cfg(all(
+  feature = "impl_core_error",
+  not(feature = "extern_crate_std"),
+  not(target_arch = "spirv")
+))]
 impl core::error::Error for CheckedCastError {}
 
 impl From<crate::PodCastError> for CheckedCastError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,11 @@ impl core::fmt::Display for PodCastError {
 impl std::error::Error for PodCastError {}
 
 // Rust 1.81+
-#[cfg(all(feature = "impl_core_error", not(feature = "extern_crate_std")))]
+#[cfg(all(
+  feature = "impl_core_error",
+  not(feature = "extern_crate_std"),
+  not(target_arch = "spirv")
+))]
 impl core::error::Error for PodCastError {}
 
 /// Re-interprets `&T` as `&[u8]`.


### PR DESCRIPTION
Fixes a build error on spirv. Display is implemented for error types on non-spirv targets, so implementing core::error::Error needs to match that.

---

Coincidentally, I think this was my fault. :scream_cat: I noticed it while mucking around with [rust-gpu](https://github.com/rust-gpu/rust-gpu).