### PR TITLE
docs: note that an empty slice still must satisfy target alignment in cast_slice/try_cast_slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,6 +504,17 @@ pub fn try_cast_mut<
 ///   that's a failure).
 /// * Similarly, you can't convert between a [ZST](https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts)
 ///   and a non-ZST.
+///
+/// ## Note
+///
+/// An empty input slice is **not** exempt from the alignment requirement. If
+/// the target type has a greater alignment than the source type then this can
+/// still fail (and [`cast_slice`] can still panic) even when the slice is
+/// empty, because the slice's data pointer must satisfy the target alignment.
+/// An empty slice such as `&[]` typically carries a dangling pointer aligned
+/// only to the source type, which may be under-aligned for the target. If you
+/// need casting an empty slice to always succeed, test for emptiness yourself
+/// and substitute an empty slice of the target type.
 #[inline]
 pub fn try_cast_slice<A: NoUninit, B: AnyBitPattern>(
   a: &[A],

--- a/tests/cast_slice_tests.rs
+++ b/tests/cast_slice_tests.rs
@@ -42,6 +42,22 @@ fn test_try_cast_slice() {
 }
 
 #[test]
+fn test_cast_slice_empty_alignment() {
+  // Regression/doc test for #342: an EMPTY slice is still subject to the
+  // target alignment requirement. Build a guaranteed 4-aligned byte slice from
+  // a [u32; 1], then `&bytes[1..1]` is a length-0 slice whose pointer is
+  // deterministically base+1 (not 4-aligned).
+  let aligned: [u32; 1] = [0];
+  let bytes: &[u8] = cast_slice(&aligned);
+  let empty_unaligned: &[u8] = &bytes[1..1];
+  assert!(empty_unaligned.is_empty());
+  assert_eq!(
+    try_cast_slice::<u8, u32>(empty_unaligned),
+    Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
+  );
+}
+
+#[test]
 fn test_try_cast_slice_mut() {
   // some align4 data
   let u32_slice: &mut [u32] = &mut [4, 5, 6];


### PR DESCRIPTION
## What

Adds a `## Note` section to the `try_cast_slice` docs clarifying that an **empty** input slice is not exempt from the alignment requirement, and adds a regression test (`test_cast_slice_empty_alignment`) that encodes this behavior.

No behavior is changed — this is a documentation + test-only change, per your comment in #342 preferring a doc note over the code change originally proposed there.

## Why

The docs for `cast_slice`/`try_cast_slice` list the alignment failure condition but never state that it also applies to empty slices. Users coming from std patterns (`Vec::new().as_ptr()`, `slice::align_to`) reasonably assume empty slices always cast successfully, but `try_cast_slice::<u8, u32>(&[])` returns `Err(TargetAlignmentGreaterAndInputNotAligned)` (and `cast_slice` panics), because an empty `&[u8]` typically carries a dangling data pointer aligned only to the source type (align 1), which fails the target's align-4 check regardless of length. Documenting the gotcha prevents surprise.

## Testing

- `cargo test --test cast_slice_tests` — new `test_cast_slice_empty_alignment` passes.
- `cargo test` and `cargo test --no-default-features` — full suite green (including doc-tests).
- `cargo doc --no-deps` — clean; the `[cast_slice]` intra-doc link resolves.

The test is deterministic on every target: it casts `[u32; 1]` to bytes (guaranteed 4-aligned base), then takes `&bytes[1..1]` — a length-0 slice whose pointer is `base + 1` (not 4-aligned) — so it does not rely on the unspecified alignment of `&[]`.

Fixes #342
