### PR TITLE
Bump bytemuck_derive to syn v3 and require rustc v1.71 for feature "derive"

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["transmute", "bytes", "casting"]
 categories = ["encoding", "no-std"]
 edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
-rust-version = "1.68"
+rust-version = "1.71"
 #note(lokathor): do not publish with this set
 #resolver = "3"
 
@@ -19,7 +19,7 @@ proc-macro = true
 
 [dependencies]
 # syn seems to have broken backwards compatibility in this version https://github.com/dtolnay/syn/issues/1194
-syn = "2.0.1"
+syn = "3"
 quote = "1"
 proc-macro2 = "1.0.60"
 


### PR DESCRIPTION
### Changes
- Upgrade the derive/proc-macro crate to syn v3 and set derive's declared MSRV to 1.71.

This change only affects the optional derive feature. The default build of bytemuck is unchanged.

### Motivation
syn v3 provides better support for newer Rust syntax and parsing bugfixes and reduces the need for multiple versions of this dependency.

### Tests performed
derive tests on 1.71: cargo +1.71.0 test --manifest-path=derive/Cargo.toml --all-targets --all-features
All tests passed.
Main crate test on current toolchain: cargo test --all-targets
All tests passed.

### Notes
Perhaps a version bump for the derive crate would also be in order.

