### PR TITLE
docs: clarify TransparentWrapper Rule 1 wording

### DIFF
--- a/src/transparent.rs
+++ b/src/transparent.rs
@@ -17,10 +17,12 @@ use super::*;
 /// For a given `Wrapper` which implements `TransparentWrapper<Inner>`:
 ///
 /// 1. `Wrapper` must be a wrapper around `Inner` with an identical data
-///    representations. This    either means that it must be a
-///    `#[repr(transparent)]` struct which    contains a either a field of type
-///    `Inner` (or a field of some other    transparent wrapper for `Inner`) as
-///    the only non-ZST field.
+///    representation. This means that it must be a `#[repr(transparent)]`
+///    struct which contains a field of type `Inner` (or a field of some other
+///    transparent wrapper for `Inner`) as the only non-ZST field.
+///
+///    See also the language rules on
+///    [ABI compatibility](https://doc.rust-lang.org/core/primitive.fn.html#abi-compatibility).
 ///
 /// 2. Any fields *other* than the `Inner` field must be trivially constructable
 ///    ZSTs, for example `PhantomData`, `PhantomPinned`, etc. (When deriving


### PR DESCRIPTION
## Problem

`TransparentWrapper` safety Rule 1 used "either" but only described one way to satisfy the rule, which made the docs confusing. The same sentence also had awkward wording ("a either", plural "representations", uneven spacing).

## Fix

- Drop the misleading "either" phrasing so Rule 1 states the single documented requirement directly
- Clean up grammar/spacing in that sentence
- Link the language [ABI compatibility](https://doc.rust-lang.org/core/primitive.fn.html#abi-compatibility) rules for readers who want the broader layout/ABI background

Docs-only change; no code behavior changes.

## Test plan

- [x] Inspect rendered safety docs in `src/transparent.rs`
- [x] Diff-only review of the Rule 1 paragraph

Fixes #265